### PR TITLE
feat(form): support number and boolean fields

### DIFF
--- a/apps/package/src/types/fields.ts
+++ b/apps/package/src/types/fields.ts
@@ -1,4 +1,4 @@
-export type FieldType = "text";
+export type FieldType = "text" | "number" | "checkbox";
 
 export type FieldDef = {
   name: string;


### PR DESCRIPTION
## Summary
- detect ZodNumber and ZodBoolean in zodToFields
- add `number` and `checkbox` field types
- render number/checkbox inputs in `wavelength-form`

## Testing
- `npm run test:jest`
- `npm run test:cypress` *(fails: missing Xvfb)*


------
https://chatgpt.com/codex/tasks/task_e_689b866c30848325ba1a22c2ee01bac8