### PR TITLE
Expose issues alongside values in form events

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { z } from "zod";
+
+import WavelengthForm from "../src/components/forms/WavelengthForm";
+import "../src/web-components/wavelength-form";
+
+// This test focuses on the React wrapper receiving the correct
+// detail payloads from the custom events.
+describe("WavelengthForm (React Wrapper)", () => {
+  test("callbacks receive value and issues", () => {
+    const onChange = jest.fn();
+    const onValid = jest.fn();
+    const onInvalid = jest.fn();
+
+    const schema = z.object({ name: z.string() });
+
+    render(
+      <WavelengthForm
+        schema={schema}
+        onChange={onChange}
+        onValid={onValid}
+        onInvalid={onInvalid}
+      />,
+    );
+
+    const host = document.querySelector("wavelength-form")!;
+
+    host.dispatchEvent(
+      new CustomEvent("form-change", {
+        detail: { value: { name: "Hello" }, issues: [] },
+      }),
+    );
+    expect(onChange).toHaveBeenCalledWith({ name: "Hello" }, []);
+
+    const issues = [{ message: "Required", path: ["name"], code: "custom" } as any];
+    host.dispatchEvent(
+      new CustomEvent("form-invalid", {
+        detail: { value: {}, issues },
+      }),
+    );
+    expect(onInvalid).toHaveBeenCalledWith({}, issues);
+
+    host.dispatchEvent(
+      new CustomEvent("form-valid", {
+        detail: { value: { name: "Hello" }, issues: [] },
+      }),
+    );
+    expect(onValid).toHaveBeenCalledWith({ name: "Hello" }, []);
+  });
+});

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -10,9 +10,10 @@ interface WavelengthFormElement extends HTMLElement {
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
 
-export type FormInvalidDetail = { issues: z.ZodIssue[] };
-export type FormValidDetail<T> = { value: T };
-export type FormChangeDetail<T> = { value: Partial<T> };
+export type FormDetail<T> = { value: T; issues: z.ZodIssue[] };
+export type FormInvalidDetail<T> = FormDetail<Partial<T>>;
+export type FormValidDetail<T> = FormDetail<T>;
+export type FormChangeDetail<T> = FormDetail<Partial<T>>;
 
 export interface WavelengthFormProps<T extends object = Record<string, unknown>> {
   /** A Zod object schema */
@@ -25,9 +26,9 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   style?: React.CSSProperties;
 
   /** Event callbacks (straight from web component custom events) */
-  onChange?: (value: Partial<T>) => void;
-  onValid?: (value: T) => void;
-  onInvalid?: (issues: z.ZodIssue[]) => void;
+  onChange?: (value: Partial<T>, issues: z.ZodIssue[]) => void;
+  onValid?: (value: T, issues: z.ZodIssue[]) => void;
+  onInvalid?: (value: Partial<T>, issues: z.ZodIssue[]) => void;
 }
 
 export interface WavelengthFormRef<T extends object = Record<string, unknown>> {
@@ -73,15 +74,15 @@ const WavelengthForm = React.forwardRef<WavelengthFormRef, WavelengthFormProps>(
 
     const handleChange = (e: Event) => {
       const detail = (e as CustomEvent<FormChangeDetail<T>>).detail;
-      onChangeStable?.(detail?.value ?? {});
+      onChangeStable?.(detail?.value ?? {}, detail?.issues ?? []);
     };
     const handleValid = (e: Event) => {
       const detail = (e as CustomEvent<FormValidDetail<T>>).detail;
-      onValidStable?.(detail?.value as T);
+      onValidStable?.(detail?.value as T, detail?.issues ?? []);
     };
     const handleInvalid = (e: Event) => {
-      const detail = (e as CustomEvent<FormInvalidDetail>).detail;
-      onInvalidStable?.(detail?.issues ?? []);
+      const detail = (e as CustomEvent<FormInvalidDetail<T>>).detail;
+      onInvalidStable?.(detail?.value ?? {}, detail?.issues ?? []);
     };
 
     el.addEventListener("form-change", handleChange as EventListener);


### PR DESCRIPTION
## Summary
- include value and issues in wavelength-form events
- forward both value and issues to React WavelengthForm callbacks
- add tests confirming onChange/onValid/onInvalid receive detail objects

## Testing
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_689b8f5bb60c8325b54f86af7f261053