### PR TITLE
Add validation tests for zod fields and WavelengthForm

### DIFF
--- a/apps/package/jest.config.js
+++ b/apps/package/jest.config.js
@@ -7,6 +7,6 @@ export default {
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   transformIgnorePatterns: ["node_modules"],
-  testMatch: ["**/**/**/*.test.(ts|tsx)"],
+  testMatch: ["<rootDir>/jest/**/*.test.ts", "<rootDir>/jest/**/*.test.tsx"],
   setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/apps/package/jest/Validator.test.ts
+++ b/apps/package/jest/Validator.test.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { Validator } from "../src/form/Validator";
+
+describe("Validator", () => {
+  const schema = z.object({
+    name: z.string().min(1),
+    age: z.number().int(),
+  });
+  const validator = new Validator(schema);
+
+  test("validate returns parsed value for valid payload", () => {
+    const res = validator.validate({ name: "Alice", age: 30 });
+    expect(res).toEqual({ isValid: true, value: { name: "Alice", age: 30 } });
+  });
+
+  test("validate reports issues for invalid payload", () => {
+    const res = validator.validate({ name: "", age: "x" } as any);
+    expect(res.isValid).toBe(false);
+    if (!res.isValid) {
+      expect(res.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("validatePartial validates only provided keys", () => {
+    const good = validator.validatePartial({ age: 40 });
+    expect(good).toEqual({ isValid: true, value: { age: 40 } });
+
+    const bad = validator.validatePartial({ age: "x" } as any);
+    expect(bad.isValid).toBe(false);
+    if (!bad.isValid) {
+      expect(bad.issues[0].path).toEqual(["age"]);
+    }
+  });
+
+  test("validateProperty validates a single field", () => {
+    expect(validator.validateProperty("age", 21)).toEqual({
+      isValid: true,
+      value: { age: 21 },
+    });
+
+    const res = validator.validateProperty("age", "bad" as any);
+    expect(res.isValid).toBe(false);
+    if (!res.isValid) {
+      expect(res.issues[0].path).toEqual(["age"]);
+    }
+  });
+});

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -1,0 +1,43 @@
+import { fireEvent } from "@testing-library/dom";
+import { z } from "zod";
+import "../../src/web-components/wavelength-form";
+
+describe("wavelength-form web component", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("emits change and valid events", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({ name: z.string() });
+
+    const change = jest.fn();
+    const valid = jest.fn();
+    el.addEventListener("form-change", (e: Event) => change((e as CustomEvent).detail));
+    el.addEventListener("form-valid", (e: Event) => valid((e as CustomEvent).detail));
+
+    const input = el.shadowRoot!.querySelector("wavelength-input") as any;
+    input.value = "A";
+    fireEvent(input, new CustomEvent("inputChange", { detail: { value: "A" } }));
+    expect(change).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
+
+    const form = el.shadowRoot!.querySelector("form")!;
+    fireEvent.submit(form);
+    expect(valid).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
+  });
+
+  test("emits invalid event on failed submission", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({ name: z.string().min(1) });
+
+    const invalid = jest.fn();
+    el.addEventListener("form-invalid", (e: Event) => invalid((e as CustomEvent).detail));
+
+    const form = el.shadowRoot!.querySelector("form")!;
+    fireEvent.submit(form);
+    expect(invalid).toHaveBeenCalled();
+    expect(invalid.mock.calls[0][0].issues.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/package/jest/zodToTextFields.test.ts
+++ b/apps/package/jest/zodToTextFields.test.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { zodToFields as zodToTextFields } from "../src/form/zodToFields";
+
+describe("zodToTextFields", () => {
+  test("maps basic types to field definitions", () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+      subscribed: z.boolean(),
+    });
+
+    expect(zodToTextFields(schema)).toEqual([
+      { name: "name", label: "Name", type: "text" },
+      { name: "age", label: "Age", type: "number" },
+      { name: "subscribed", label: "Subscribed", type: "checkbox" },
+    ]);
+  });
+
+  test("unwraps optional and default wrappers", () => {
+    const schema = z.object({
+      title: z.string().optional(),
+      count: z.number().nullable().default(0),
+      active: z.boolean().default(false),
+    });
+
+    expect(zodToTextFields(schema)).toEqual([
+      { name: "title", label: "Title", type: "text" },
+      { name: "count", label: "Count", type: "number" },
+      { name: "active", label: "Active", type: "checkbox" },
+    ]);
+  });
+
+  test("ignores unsupported types", () => {
+    const schema = z.object({
+      tags: z.array(z.string()),
+      profile: z.object({ nickname: z.string() }),
+    });
+
+    expect(zodToTextFields(schema)).toEqual([]);
+  });
+});

--- a/apps/package/src/form/zodToFields.ts
+++ b/apps/package/src/form/zodToFields.ts
@@ -11,9 +11,16 @@ type Shape = ZodRawShape;
  */
 function unwrap(t: ZodTypeAny): ZodTypeAny {
   let cur: any = t;
-  // Walk through possible wrapper keys until we reach a core type
-  while (cur && cur._def && (cur._def.innerType || cur._def.type || cur._def.schema)) {
-    cur = cur._def.innerType ?? cur._def.type ?? cur._def.schema;
+  // Walk through wrapper keys until reaching a primitive type. In Zod v4 the
+  // `_def.type` for primitives is a string (e.g. "string"), so only unwrap when
+  // these keys point to another Zod type object.
+  while (cur && cur._def) {
+    const next = cur._def.innerType || cur._def.schema || cur._def.type;
+    if (next && typeof next === "object") {
+      cur = next;
+    } else {
+      break;
+    }
   }
   return cur as ZodTypeAny;
 }


### PR DESCRIPTION
## Summary
- expand zod field mapping utilities to unwrap v4 schemas
- exercise zodToTextFields against multiple schema shapes
- cover Validator and web-component event flows via DOM testing

## Testing
- `npm run test:jest`
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689ba30cbda0832580d592d6ce147043