### PR TITLE
feat: use custom button and configurable submit label

### DIFF
--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -22,8 +22,8 @@ describe("wavelength-form web component", () => {
     fireEvent(input, new CustomEvent("inputChange", { detail: { value: "A" } }));
     expect(change).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
 
-    const form = el.shadowRoot!.querySelector("form")!;
-    fireEvent.submit(form);
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
+    fireEvent.click(button);
     expect(valid).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
   });
 
@@ -35,9 +35,16 @@ describe("wavelength-form web component", () => {
     const invalid = jest.fn();
     el.addEventListener("form-invalid", (e: Event) => invalid((e as CustomEvent).detail));
 
-    const form = el.shadowRoot!.querySelector("form")!;
-    fireEvent.submit(form);
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
+    fireEvent.click(button);
     expect(invalid).toHaveBeenCalled();
     expect(invalid.mock.calls[0][0].issues.length).toBeGreaterThan(0);
+  });
+
+  test("submit-label attribute controls button text", () => {
+    document.body.innerHTML = `<wavelength-form submit-label="Go"></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
+    expect(button.textContent).toBe("Go");
   });
 });

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -20,6 +20,8 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   schema: z.ZodType<T>;
   /** Initial or controlled value (partial OK) */
   value?: Partial<T>;
+  /** Label for the submit button */
+  submitLabel?: string;
 
   /** Standard React props */
   className?: string;
@@ -49,7 +51,7 @@ function useStableCallback<F extends (...args: any[]) => any>(fn?: F) {
 }
 
 function WavelengthFormInner<T extends object = Record<string, unknown>>(
-  { schema, value, className, style, onChange, onValid, onInvalid }: WavelengthFormProps<T>,
+  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel }: WavelengthFormProps<T>,
   ref: React.ForwardedRef<WavelengthFormRef<T>>,
 ) {
   const hostRef = useRef<WavelengthFormElement | null>(null);
@@ -109,7 +111,14 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     [],
   );
 
-  return <wavelength-form ref={hostRef as any} className={className} style={style} />;
+  return (
+    <wavelength-form
+      ref={hostRef as any}
+      className={className}
+      style={style}
+      submit-label={submitLabel}
+    />
+  );
 }
 
 const WavelengthForm = React.forwardRef(WavelengthFormInner) as <T extends object = Record<string, unknown>>(

--- a/apps/package/src/types/global.d.ts
+++ b/apps/package/src/types/global.d.ts
@@ -42,7 +42,9 @@ declare namespace JSX {
       id?: string;
     };
 
-    "wavelength-form": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    "wavelength-form": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+      "submit-label"?: string;
+    };
 
     "wavelength-progress-bar": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
 


### PR DESCRIPTION
## Summary
- replace native submit button with `<wavelength-button>` and forward clicks to form submission
- add `submitLabel` property/attribute to control button text
- expose `submitLabel` through React wrapper and global types

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689c112fefa8832593d2a9b46f70623d