### PR TITLE
feat(form): expose submit button props

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -42,4 +42,18 @@ describe("WavelengthForm (React Wrapper)", () => {
     );
     expect(onValid).toHaveBeenCalledWith({ name: "Hello" }, []);
   });
+
+  test("forwards submit props", async () => {
+    const schema = z.object({ name: z.string() });
+    render(<WavelengthForm schema={schema} submitLabel="Go" submitButtonProps={{ variant: "contained", colorOne: "red" }} />);
+
+    const host = document.querySelector("wavelength-form") as any;
+    // wait for effects
+    await new Promise((r) => setTimeout(r, 0));
+
+    const button = host.shadowRoot.querySelector("wavelength-button");
+    expect(button).toHaveAttribute("variant", "contained");
+    expect(button).toHaveAttribute("color-one", "red");
+    expect(button.textContent).toContain("Go");
+  });
 });

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useImperativeHandle, useRef } from "react";
 import { z } from "zod";
+import type { WavelengthButtonProps } from "../buttons/WavelengthButton/WavelengthButton";
 
 // ---- Types that mirror the web component's API ----
 interface WavelengthFormElement extends HTMLElement {
   schema?: unknown;
   value?: Record<string, unknown>;
   validate?: () => boolean;
+  submitLabel?: string;
+  submitButtonProps?: Record<string, unknown>;
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
@@ -22,6 +25,8 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   value?: Partial<T>;
   /** Label for the submit button */
   submitLabel?: string;
+  /** Props forwarded to the internal wavelength-button */
+  submitButtonProps?: Omit<WavelengthButtonProps, "children" | "onClick">;
 
   /** Standard React props */
   className?: string;
@@ -51,7 +56,7 @@ function useStableCallback<F extends (...args: any[]) => any>(fn?: F) {
 }
 
 function WavelengthFormInner<T extends object = Record<string, unknown>>(
-  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel }: WavelengthFormProps<T>,
+  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel, submitButtonProps }: WavelengthFormProps<T>,
   ref: React.ForwardedRef<WavelengthFormRef<T>>,
 ) {
   const hostRef = useRef<WavelengthFormElement | null>(null);
@@ -68,7 +73,9 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     // Set schema/value as *properties* (not attributes)
     el.schema = schema;
     if (value) el.value = value as any;
-  }, [schema, value]);
+    if (submitLabel !== undefined) el.submitLabel = submitLabel;
+    if (submitButtonProps) el.submitButtonProps = submitButtonProps as any;
+  }, [schema, value, submitLabel, submitButtonProps]);
 
   useEffect(() => {
     const el = hostRef.current;
@@ -111,7 +118,7 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     [],
   );
 
-  return <wavelength-form ref={hostRef as any} className={className} style={style} submit-label={submitLabel} />;
+  return <wavelength-form ref={hostRef as any} className={className} style={style} />;
 }
 
 const WavelengthForm = React.forwardRef(WavelengthFormInner) as <T extends object = Record<string, unknown>>(

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -14,6 +14,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   private _value: FormValue = {};
   private _errors: Record<string, string> = {};
   private _submitLabel = "Submit";
+  private _submitButtonProps: Record<string, unknown> = {};
 
   static get observedAttributes() {
     // schema is a property, not an attribute
@@ -60,6 +61,14 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   }
   get submitLabel(): string {
     return this._submitLabel;
+  }
+
+  set submitButtonProps(v: Record<string, unknown> | undefined) {
+    this._submitButtonProps = v ?? {};
+    this.render();
+  }
+  get submitButtonProps(): Record<string, unknown> {
+    return this._submitButtonProps;
   }
 
   /**
@@ -281,6 +290,22 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     actions.className = "actions";
     const submit = document.createElement("wavelength-button");
     submit.textContent = this._submitLabel;
+    for (const [key, val] of Object.entries(this._submitButtonProps)) {
+      if (key === "className") {
+        submit.className = String(val ?? "");
+        continue;
+      }
+      if (key === "style" && typeof val === "object") {
+        Object.assign((submit as HTMLElement).style, val as Record<string, any>);
+        continue;
+      }
+      const attr = key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+      if (typeof val === "boolean") {
+        if (val) submit.setAttribute(attr, "");
+      } else {
+        submit.setAttribute(attr, String(val));
+      }
+    }
     submit.addEventListener("click", (e) => {
       e.preventDefault();
       if (typeof (form as any).requestSubmit === "function") {

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -29,6 +29,11 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
 <WavelengthForm schema={schema} value={{ firstName: 'Clark', lastName: 'Kent' }} />`}
             language="tsx"
           />
+          <p>
+            Customize the submit button text with <code>submitLabel</code> or pass
+            <code>submitButtonProps</code> to forward attributes to the internal
+            <code>&lt;wavelength-button&gt;</code>.
+          </p>
           <h2>Example</h2>
           <Canvas />
           <h2>Props</h2>
@@ -41,6 +46,11 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
   argTypes: {
     schema: { control: "object", description: "Zod schema defining form shape" },
     value: { control: "object", description: "Initial form values" },
+    submitLabel: { control: "text", description: "Label for the submit button" },
+    submitButtonProps: {
+      control: "object",
+      description: "Props forwarded to the internal wavelength-button",
+    },
   },
   args: {
     schema: sampleSchema,
@@ -54,5 +64,15 @@ export default meta;
 type Story = StoryObj<typeof WavelengthForm>;
 
 export const Default: Story = {
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const CustomSubmitButton: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    submitLabel: "Register",
+    submitButtonProps: { variant: "contained", colorOne: "#2e7d32", colorTwo: "#fff" },
+  },
   render: (args) => <WavelengthForm {...args} />,
 };


### PR DESCRIPTION
## Summary
- allow WavelengthForm to pass submit button props through to underlying web component
- support forwarding to internal button in web component
- document submitLabel and submitButtonProps and show customization in story

## Testing
- `npm run lint`
- `npm run test:jest`
- `npm run test:cypress` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689c2308d9908325ad38ececefc9b77e