### PR TITLE
Clear validation error when error attributes removed

### DIFF
--- a/apps/package/jest/wavelength-input.test.tsx
+++ b/apps/package/jest/wavelength-input.test.tsx
@@ -128,6 +128,22 @@ describe("<wavelength-input>", () => {
     expect(helper.textContent).toContain("Forced error");
   });
 
+  test("clears error when force-error and error-message removed", () => {
+    element.setAttribute("helper-message", "help text");
+    element.setAttribute("force-error", "");
+    element.setAttribute("error-message", "Forced error");
+
+    let helper = element.shadowRoot!.querySelector(".helper-message")!;
+    expect(helper.textContent).toContain("Forced error");
+
+    element.removeAttribute("force-error");
+    element.removeAttribute("error-message");
+
+    helper = element.shadowRoot!.querySelector(".helper-message")!;
+    expect(helper.textContent).toBe("help text");
+    expect(element.hasAttribute("data-error")).toBe(false);
+  });
+
   test("sets accessibility attributes on input", () => {
     element.setAttribute("required", "");
     document.body.innerHTML = `<wavelength-input required></wavelength-input>`;
@@ -246,6 +262,8 @@ describe("<wavelength-input>", () => {
   test.each([
     ["label", null, "Test"],
     ["helper-message", null, "Text"],
+    ["error-message", null, "Error"],
+    ["force-error", null, ""],
     ["validation-type", "none", "always"],
     ["value", "abc", "xyz"],
     ["clearable", null, ""],

--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -583,6 +583,13 @@ export class WavelengthInput extends HTMLElement {
       case "helper-message":
         this._applyValidationHint();
         break;
+      case "error-message":
+      case "force-error":
+        this._applyAttributes();
+        if (!this.hasAttribute("error-message") && !this.hasAttribute("force-error")) {
+          this._clearError(this.getAttribute("helper-message") || "");
+        }
+        break;
       case "validation-type":
         this.validationType = validTypes.includes(newValue as string) ? (newValue as typeof this.validationType) : "none";
         break;


### PR DESCRIPTION
## Summary
- handle `error-message` and `force-error` in `attributeChangedCallback`
- reset error state when those attributes are removed
- add regression test verifying error clears and extend attributeChangedCallback coverage

## Testing
- `npm run test:jest`
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689c99af4cb48325a921ad728bfded12