### PR TITLE
Respect empty custom validation messages

### DIFF
--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -137,7 +137,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       this.setFieldError(name, undefined);
     } else {
       const issue = res.issues?.find((i) => (i.path?.[0] as string) === name);
-      this.setFieldError(name, issue?.message || "Invalid value");
+      this.setFieldError(name, issue?.message ?? "Invalid value");
     }
   }
 

--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -336,7 +336,7 @@ export class WavelengthInput extends HTMLElement {
     const errors: string[] = [];
 
     if (force) {
-      errors.push(errorMessage || "Invalid input.");
+      errors.push(errorMessage ?? "Invalid input.");
     }
 
     if (isRequired && isEmpty && shouldValidate) {
@@ -347,7 +347,7 @@ export class WavelengthInput extends HTMLElement {
       try {
         const regex = new RegExp(regexAttr);
         if (!regex.test(value)) {
-          errors.push(errorMessage || "Input does not match the required pattern.");
+          errors.push(errorMessage ?? "Input does not match the required pattern.");
         }
       } catch (e) {
         console.warn(`[WavelengthInput] Invalid regex pattern: "${regexAttr}"`, e);
@@ -357,12 +357,12 @@ export class WavelengthInput extends HTMLElement {
 
     const min = parseInt(minLengthAttr ?? "", 10);
     if (!isNaN(min) && value.length < min && shouldValidate) {
-      errors.push(minLengthMessage || `MINIMUM length is ${min} characters.`);
+      errors.push(minLengthMessage ?? `MINIMUM length is ${min} characters.`);
     }
 
     const max = parseInt(maxLengthAttr ?? "", 10);
     if (!isNaN(max) && value.length > max && shouldValidate) {
-      errors.push(maxLengthMessage || `MAXIMUM length is ${max} characters.`);
+      errors.push(maxLengthMessage ?? `MAXIMUM length is ${max} characters.`);
     }
 
     if (errors.length > 0) {


### PR DESCRIPTION
## Summary
- Preserve blank Zod issue messages in wavelength-form
- Allow wavelength-input to show blank `error-message`, `min-length-message`, and `max-length-message`

## Testing
- `npm test` (jest portion)
- `npm run test:cypress` *(fails: missing Xvfb)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ca0424224832584eeb20710676e0f