### PR TITLE
Handle empty string error messages in wavelength-form

### DIFF
--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -27,10 +27,10 @@ describe("wavelength-form web component", () => {
     expect(valid).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
   });
 
-  test("emits invalid event on failed submission", () => {
+  test("emits invalid event and shows empty error message", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;
-    el.schema = z.object({ name: z.string().min(1) });
+    el.schema = z.object({ name: z.string().min(1, { message: "" }) });
 
     const invalid = jest.fn();
     el.addEventListener("form-invalid", (e: Event) => invalid((e as CustomEvent).detail));
@@ -39,6 +39,10 @@ describe("wavelength-form web component", () => {
     fireEvent.click(button);
     expect(invalid).toHaveBeenCalled();
     expect(invalid.mock.calls[0][0].issues.length).toBeGreaterThan(0);
+
+    const input = el.shadowRoot!.querySelector("wavelength-input")!;
+    expect(input.getAttribute("error-message")).toBe("");
+    expect(input.hasAttribute("force-error")).toBe(true);
   });
 
   test("submit-label attribute controls button text", () => {

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -119,7 +119,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     const el = this.queryFieldEl(name);
     if (!el) return;
 
-    if (message) {
+    if (message !== undefined && message !== null) {
       el.setAttribute("error-message", message);
       el.setAttribute("force-error", "");
       this._errors[name] = message;


### PR DESCRIPTION
## Summary
- treat empty string messages as errors in `wavelength-form` by explicitly checking for null/undefined
- test that an empty validation message still triggers error state with no text

## Testing
- `npm run lint`
- `npm run test:jest`
- `npm run test:cypress` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689ca9abadac8325ab7cd6b5225e1934