### PR TITLE
Handle multiple field validation messages

### DIFF
--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/dom";
 import { z } from "zod";
 import "../../src/web-components/wavelength-form";
+import "../../src/web-components/wavelength-input";
 
 describe("wavelength-form web component", () => {
   afterEach(() => {
@@ -43,6 +44,26 @@ describe("wavelength-form web component", () => {
     const input = el.shadowRoot!.querySelector("wavelength-input")!;
     expect(input.getAttribute("error-message")).toBe("");
     expect(input.hasAttribute("force-error")).toBe(true);
+  });
+
+  test("renders multiple error messages", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({
+      password: z
+        .string()
+        .min(5, { message: "Too short" })
+        .regex(/[A-Z]/, { message: "Must include capital" }),
+    });
+
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
+    fireEvent.click(button);
+
+    const input = el.shadowRoot!.querySelector("wavelength-input") as any;
+    expect(input.getAttribute("error-message")).toBe("Too short\nMust include capital");
+
+    const helper = input.shadowRoot!.getElementById("helper")!;
+    expect(helper.innerHTML).toContain("Too short<br>Must include capital");
   });
 
   test("submit-label attribute controls button text", () => {


### PR DESCRIPTION
## Summary
- group field validation issues and merge their messages
- keep accumulating messages via `setFieldError`
- test multiple error messages rendering on wavelength-form

## Testing
- `npm run test:jest`
- `npm run test:cypress` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689cc5a418048325a7a5f051af773ff8