### PR TITLE
feat: honor custom error message

### DIFF
--- a/apps/package/jest/WavelengthInput.test.tsx
+++ b/apps/package/jest/WavelengthInput.test.tsx
@@ -146,4 +146,25 @@ describe("WavelengthInput (React Wrapper)", () => {
     expect(el).toHaveAttribute("focus-color", "#444");
     expect(el).toHaveAttribute("helper-color", "#666");
   });
+
+  test("defaults to required message when forceError without errorMessage", () => {
+    render(<WavelengthInput data-testid="wavelength-input" forceError required />);
+    const el = screen.getByTestId("wavelength-input") as HTMLElement;
+    const helper = el.shadowRoot?.querySelector(".helper-message") as HTMLElement;
+    expect(helper.textContent).toBe("This field is required.");
+  });
+
+  test("uses provided errorMessage when present with forceError", () => {
+    render(
+      <WavelengthInput
+        data-testid="wavelength-input"
+        forceError
+        required
+        errorMessage="Custom error"
+      />,
+    );
+    const el = screen.getByTestId("wavelength-input") as HTMLElement;
+    const helper = el.shadowRoot?.querySelector(".helper-message") as HTMLElement;
+    expect(helper.textContent).toContain("Custom error");
+  });
 });

--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -332,37 +332,50 @@ export class WavelengthInput extends HTMLElement {
       return true;
     }
 
-    const shouldValidate = bypassTypeCheck || force || validationType === "always" || (validationType === "onBlur" && this.hasBlurred);
+    const shouldValidate =
+      bypassTypeCheck ||
+      validationType === "always" ||
+      (validationType === "onBlur" && this.hasBlurred);
     const errors: string[] = [];
 
     if (force) {
-      errors.push(errorMessage ?? "Invalid input.");
-    }
-
-    if (isRequired && isEmpty && shouldValidate) {
-      errors.push("This field is required.");
-    }
-
-    if (regexAttr && !isEmpty && shouldValidate) {
-      try {
-        const regex = new RegExp(regexAttr);
-        if (!regex.test(value)) {
-          errors.push(errorMessage ?? "Input does not match the required pattern.");
-        }
-      } catch (e) {
-        console.warn(`[WavelengthInput] Invalid regex pattern: "${regexAttr}"`, e);
-        errors.push("Invalid regex pattern.");
+      if (errorMessage) {
+        errors.push(errorMessage);
+      } else {
+        errors.push("This field is required.");
       }
     }
 
-    const min = parseInt(minLengthAttr ?? "", 10);
-    if (!isNaN(min) && value.length < min && shouldValidate) {
-      errors.push(minLengthMessage ?? `MINIMUM length is ${min} characters.`);
-    }
+    if (!force) {
+      if (isRequired && isEmpty && shouldValidate) {
+        if (this.hasAttribute("error-message") && errorMessage) {
+          errors.push(errorMessage);
+        } else {
+          errors.push("This field is required.");
+        }
+      }
 
-    const max = parseInt(maxLengthAttr ?? "", 10);
-    if (!isNaN(max) && value.length > max && shouldValidate) {
-      errors.push(maxLengthMessage ?? `MAXIMUM length is ${max} characters.`);
+      if (regexAttr && !isEmpty && shouldValidate) {
+        try {
+          const regex = new RegExp(regexAttr);
+          if (!regex.test(value)) {
+            errors.push(errorMessage ?? "Input does not match the required pattern.");
+          }
+        } catch (e) {
+          console.warn(`[WavelengthInput] Invalid regex pattern: "${regexAttr}"`, e);
+          errors.push("Invalid regex pattern.");
+        }
+      }
+
+      const min = parseInt(minLengthAttr ?? "", 10);
+      if (!isNaN(min) && value.length < min && shouldValidate) {
+        errors.push(minLengthMessage ?? `MINIMUM length is ${min} characters.`);
+      }
+
+      const max = parseInt(maxLengthAttr ?? "", 10);
+      if (!isNaN(max) && value.length > max && shouldValidate) {
+        errors.push(maxLengthMessage ?? `MAXIMUM length is ${max} characters.`);
+      }
     }
 
     if (errors.length > 0) {


### PR DESCRIPTION
## Summary
- respect custom error messages when validating WavelengthInput
- ensure force-error falls back to default required message when no error-message provided
- add tests for required message with and without error-message

## Testing
- `npm run test:jest -- apps/package/jest/WavelengthInput.test.tsx apps/package/jest/wavelength-input.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cc9d68988832586dbf6eaf2bc8913