### PR TITLE
Avoid redundant helper message updates

### DIFF
--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -390,6 +390,10 @@ export class WavelengthInput extends HTMLElement {
 
   private _showError(message: string) {
     const htmlMessage = message.replace(/\n/g, "<br>");
+    if (this.helperEl.innerHTML === htmlMessage) {
+      this._lastErrorMessage = message;
+      return;
+    }
     this.helperEl.innerHTML = htmlMessage;
     this.helperEl.classList.add("error");
     this.inputEl.style.borderColor = "red";


### PR DESCRIPTION
## Summary
- skip resetting helper message when it already matches the last HTML

## Testing
- `npm run lint`
- `npm run test:jest`
- `npm run build:package`


------
https://chatgpt.com/codex/tasks/task_e_689cd5970b84832584873880d9d2d273