### PR TITLE
test: ensure error message stable on repeated blur

### DIFF
--- a/apps/package/jest/WavelengthInput.test.tsx
+++ b/apps/package/jest/WavelengthInput.test.tsx
@@ -162,15 +162,25 @@ describe("WavelengthInput (React Wrapper)", () => {
   });
 
   test("shows error message only once when blurred multiple times", () => {
-    render(<WavelengthInput data-testid="wavelength-input" required validationType="onBlur" />);
+    render(
+      <WavelengthInput
+        data-testid="wavelength-input"
+        required
+        validationType="onBlur"
+        errorMessage="Username is required."
+      />,
+    );
     const el = screen.getByTestId("wavelength-input") as HTMLElement;
     const input = el.shadowRoot?.querySelector("input") as HTMLInputElement;
 
+    fireEvent.focus(input);
     fireEvent.blur(input);
+    fireEvent.focus(input);
     fireEvent.blur(input);
+    fireEvent.focus(input);
     fireEvent.blur(input);
 
     const helper = el.shadowRoot?.querySelector(".helper-message") as HTMLElement;
-    expect(helper.innerHTML).toBe("This field is required.");
+    expect(helper.textContent).toBe("Username is required.");
   });
 });


### PR DESCRIPTION
## Summary
- add focus events in WavelengthInput test to mimic user interactions
- assert the required error shows only once after repeated focus/blur cycles

## Testing
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_689cd5988edc8325914ffcf223e3e32e