### PR TITLE
Ensure default required message is always shown

### DIFF
--- a/apps/package/jest/WavelengthInput.test.tsx
+++ b/apps/package/jest/WavelengthInput.test.tsx
@@ -158,7 +158,7 @@ describe("WavelengthInput (React Wrapper)", () => {
     render(<WavelengthInput data-testid="wavelength-input" forceError required errorMessage="Custom error" />);
     const el = screen.getByTestId("wavelength-input") as HTMLElement;
     const helper = el.shadowRoot?.querySelector(".helper-message") as HTMLElement;
-    expect(helper.textContent).toContain("Custom error");
+    expect(helper.innerHTML).toBe("Custom error<br>This field is required.");
   });
 
   test("shows error message only once when blurred multiple times", () => {

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -42,8 +42,8 @@ describe("wavelength-form web component", () => {
     expect(invalid.mock.calls[0][0].issues.length).toBeGreaterThan(0);
 
     const input = el.shadowRoot!.querySelector("wavelength-input")!;
-    expect(input.getAttribute("error-message")).toBe("");
-    expect(input.hasAttribute("force-error")).toBe(true);
+    expect(input.getAttribute("error-message")).toBeNull();
+    expect(input.hasAttribute("force-error")).toBe(false);
   });
 
   test("renders multiple error messages", () => {
@@ -60,7 +60,7 @@ describe("wavelength-form web component", () => {
     expect(input.getAttribute("error-message")).toBe("Too short\nMust include capital");
 
     const helper = input.shadowRoot!.getElementById("helper")!;
-    expect(helper.innerHTML).toContain("Too short<br>Must include capital");
+    expect(helper.innerHTML).toContain("Too short<br>Must include capital<br>This field is required.");
   });
 
   test("submit-label attribute controls button text", () => {

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -119,7 +119,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     const el = this.queryFieldEl(name);
     if (!el) return;
 
-    if (message !== undefined && message !== null) {
+    if (message) {
       const existing = this._errors[name];
       const combined = existing ? `${existing}\n${message}` : message;
       el.setAttribute("error-message", combined);

--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -339,18 +339,16 @@ export class WavelengthInput extends HTMLElement {
     if (force) {
       if (errorMessage) {
         errors.add(errorMessage);
-      } else {
-        errors.add("This field is required.");
       }
+      errors.add("This field is required.");
     }
 
     if (!force) {
       if (isRequired && isEmpty && shouldValidate) {
-        if (this.hasAttribute("error-message") && errorMessage) {
+        if (errorMessage) {
           errors.add(errorMessage);
-        } else {
-          errors.add("This field is required.");
         }
+        errors.add("This field is required.");
       }
 
       if (regexAttr && !isEmpty && shouldValidate) {


### PR DESCRIPTION
## Summary
- Always include "This field is required." when validation fails in `wavelength-input`
- Restore `setFieldError` to clear errors when message is empty
- Update tests for combined error messages and empty message behavior

## Testing
- `npm run test:jest`
- `npm run test:cypress` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689cdbd688988325bfd6df8cc83d43c5