### PR TITLE
Deduplicate error messages in WavelengthForm

### DIFF
--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -63,6 +63,23 @@ describe("wavelength-form web component", () => {
     expect(helper.innerHTML).toContain("Too short<br>Must include capital<br>This field is required.");
   });
 
+  test("deduplicates error messages on re-render and blur", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({ name: z.string().min(1, { message: "Required" }) });
+
+    let input = el.shadowRoot!.querySelector("wavelength-input") as any;
+    fireEvent.blur(input);
+    expect(input.getAttribute("error-message")).toBe("Required");
+
+    // Re-render the form and blur again
+    el.render();
+    input = el.shadowRoot!.querySelector("wavelength-input") as any;
+    fireEvent.blur(input);
+    fireEvent.blur(input);
+    expect(input.getAttribute("error-message")).toBe("Required");
+  });
+
   test("submit-label attribute controls button text", () => {
     document.body.innerHTML = `<wavelength-form submit-label="Go"></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -121,7 +121,8 @@ export class WavelengthForm<T extends object> extends HTMLElement {
 
     if (message) {
       const existing = this._errors[name];
-      const combined = existing ? `${existing}\n${message}` : message;
+      const pieces = [...(existing ? existing.split("\n") : []), ...message.split("\n")].filter((m) => m !== "");
+      const combined = Array.from(new Set(pieces)).join("\n");
       el.setAttribute("error-message", combined);
       el.setAttribute("force-error", "");
       this._errors[name] = combined;


### PR DESCRIPTION
## Summary
- ensure WavelengthForm tracks unique error messages per field
- test that re-rendering and blurring does not duplicate errors

## Testing
- `npm run lint` *(fails: prettier errors in unrelated files)*
- `npx eslint apps/package/src/web-components/wavelength-form.ts apps/package/jest/web-components/wavelength-form.test.ts`
- `npm run test:jest` *(fails: WavelengthInput.test.tsx)*
- `npm run test:cypress` *(fails: missing Xvfb dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689f68120d7c8325a080f1dcb2da912a