### PR TITLE
Respect existing errors on blur

### DIFF
--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -302,9 +302,17 @@ export class WavelengthInput extends HTMLElement {
     }
 
     const shouldValidate = this.validationType === "onBlur" || this.validationType === "always";
+    let isValid = true;
+    if (shouldValidate) {
+      isValid = this._validate();
+    }
+
+    const hasError = this.hasAttribute("data-error") || this.hasAttribute("force-error");
+    if (hasError) {
+      return;
+    }
 
     if (shouldValidate) {
-      const isValid = this._validate();
       if (isValid) {
         this.inputEl.style.borderColor = this.getAttribute("border-color") || "#cccccc";
       }


### PR DESCRIPTION
## Summary
- Avoid resetting border color on blur when `data-error` or `force-error` is present

## Testing
- `npm run test:jest` *(fails: WavelengthInput (React Wrapper) shows error message only once when blurred multiple times)*

------
https://chatgpt.com/codex/tasks/task_e_689f681210d48325b8a1d908522ae2a2