### PR TITLE
feat(testbed): add playground page

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -6,6 +6,10 @@
 
 2. Be a Maintainer/Owner for the `@wavelengthusaf/components` npm package.
 
+### Playground
+
+The testbed includes a `Playground` page (`/Playground`) that acts as a blank canvas for experimenting with components outside of Storybook.
+
 ## Instructions
 
 1. After cloning the repo from GitLab, run the command `git checkout -b <branch>`. If you are working a ticket, make sure that you name your branch after the corresponding ticket number.

--- a/apps/testbed/src/App.tsx
+++ b/apps/testbed/src/App.tsx
@@ -34,6 +34,7 @@ import PageFileDownloader from "./pages/PageFileDownloader";
 import PageDropdown from "./pages/PageDropdown";
 import PageSlider from "./pages/PageSlider";
 import PageFaq from "./pages/PageFaq";
+import PagePlayground from "./pages/PagePlayground";
 import { WavelengthFooter } from "@wavelengthusaf/components";
 import PageStyledButton from "./pages/PageStyledButton";
 // import PageTextField from "./pages/PageTextField";
@@ -71,6 +72,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<PageHome />} />
           <Route path="/Faqs" element={<PageFaq />} />
+          <Route path="/Playground" element={<PagePlayground />} />
           <Route path="/Button" element={<PageButton />} />
           <Route path="/SearchBar" element={<PageSearchBar />} />
           <Route path="/Title&Subtitle" element={<PageTitle />} />

--- a/apps/testbed/src/components/Frame/Frame.tsx
+++ b/apps/testbed/src/components/Frame/Frame.tsx
@@ -16,6 +16,7 @@ const sections = [
         items: [
           { title: "Instructions", path: "/" },
           { title: "FAQs", path: "/Faqs" },
+          { title: "Playground", path: "/Playground" },
         ],
       },
     ],

--- a/apps/testbed/src/pages/PagePlayground.tsx
+++ b/apps/testbed/src/pages/PagePlayground.tsx
@@ -1,0 +1,14 @@
+import ComponentContainer from "../components/ComponentContainer/ComponentContainer";
+
+function PagePlayground() {
+  return (
+    <>
+      <span className="page-name">Playground</span>
+      <ComponentContainer>
+        <p>Use this space to experiment with components outside of Storybook.</p>
+      </ComponentContainer>
+    </>
+  );
+}
+
+export default PagePlayground;


### PR DESCRIPTION
## Summary
- add simple Playground page for ad-hoc component testing
- wire up route and sidebar entry for Playground
- document Playground usage in developer readme

## Testing
- `npm test` *(fails: WavelengthInput test)*
- `npm run lint` *(fails: prettier errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689f71e3589c8325badc2dfb31889b27