### PR TITLE
fix: support shadow DOM ancestor traversal for color detection

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import WavelengthForm from "../src/components/forms/WavelengthForm";
 import "../src/web-components/wavelength-form";
+import "../src/web-components/wavelength-input";
 
 // This test focuses on the React wrapper receiving the correct
 // detail payloads from the custom events.
@@ -55,5 +56,23 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(button).toHaveAttribute("variant", "contained");
     expect(button).toHaveAttribute("color-one", "red");
     expect(button.textContent).toContain("Go");
+  });
+
+  test("propagates container background to inputs", async () => {
+    const schema = z.object({ name: z.string() });
+    const color = "rgb(1, 2, 3)";
+    const { container } = render(
+      <div style={{ backgroundColor: color }}>
+        <WavelengthForm schema={schema} />
+      </div>,
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = container.querySelector("wavelength-form") as any;
+    const input = host.shadowRoot.querySelector("wavelength-input") as any;
+    const label = input.shadowRoot.getElementById("floating-label") as HTMLElement;
+
+    expect(label.style.getPropertyValue("--wavelength-container-background")).toBe(color);
   });
 });

--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -134,6 +134,15 @@ template.innerHTML = `
 <div class="helper-message" id="helper"></div>
 `;
 
+function getAncestor(el: HTMLElement | null): HTMLElement | null {
+  if (!el) return null;
+  if (el.parentElement) {
+    return el.parentElement;
+  }
+  const root = el.getRootNode();
+  return root instanceof ShadowRoot ? (root.host as HTMLElement) : null;
+}
+
 export class WavelengthInput extends HTMLElement {
   private inputEl: HTMLInputElement;
   private labelEl: HTMLLabelElement;
@@ -245,13 +254,13 @@ export class WavelengthInput extends HTMLElement {
       requestAnimationFrame(() => this._applyColors());
     });
 
-    let ancestor: HTMLElement | null = this.parentElement;
+    let ancestor: HTMLElement | null = getAncestor(this);
     while (ancestor && ancestor !== document.body) {
       this._bgObserver.observe(ancestor, {
         attributes: true,
         attributeFilter: ["class", "style"],
       });
-      ancestor = ancestor.parentElement;
+      ancestor = getAncestor(ancestor);
     }
 
     this._bgObserver.observe(document.body, {
@@ -353,10 +362,7 @@ export class WavelengthInput extends HTMLElement {
 
     if (!force) {
       if (isRequired && isEmpty && shouldValidate) {
-        if (errorMessage) {
-          errors.add(errorMessage);
-        }
-        errors.add("This field is required.");
+        errors.add(errorMessage ?? "This field is required.");
       }
 
       if (regexAttr && !isEmpty && shouldValidate) {
@@ -549,7 +555,7 @@ export class WavelengthInput extends HTMLElement {
         containerBg = bg;
         break;
       }
-      el = el.parentElement;
+      el = getAncestor(el);
     }
 
     this.inputEl.style.backgroundColor = InputBg;


### PR DESCRIPTION
## Summary
- allow `wavelength-input` to walk up through shadow DOM hosts when checking ancestor backgrounds
- observe background changes on all ancestors up to `document.body`
- test that `WavelengthForm` propagates container background color to internal inputs
- fix validation to show custom required message without duplicating default text

## Testing
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_68a4b58975d48325b5a5320760c4b36c