### PR TITLE
feat: allow custom IDs in WavelengthForm inputs

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -75,4 +75,20 @@ describe("WavelengthForm (React Wrapper)", () => {
 
     expect(label.style.getPropertyValue("--wavelength-container-background")).toBe(color);
   });
+
+  test("applies idPrefix to generated inputs", async () => {
+    const schema = z.object({ agree: z.boolean(), name: z.string() });
+    render(<WavelengthForm schema={schema} idPrefix="test" />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const checkbox = host.shadowRoot!.querySelector("input[type='checkbox']")! as HTMLInputElement;
+    const label = host.shadowRoot!.querySelector("label")! as HTMLLabelElement;
+    const text = host.shadowRoot!.querySelector("wavelength-input")!;
+
+    expect(checkbox.id).toBe("test-agree");
+    expect(label.htmlFor).toBe("test-agree");
+    expect(text.getAttribute("id")).toBe("test-name");
+  });
 });

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -86,4 +86,19 @@ describe("wavelength-form web component", () => {
     const button = el.shadowRoot!.querySelector("wavelength-button")!;
     expect(button.textContent).toBe("Go");
   });
+
+  test("generates ids and links checkbox labels", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.idPrefix = "form";
+    el.schema = z.object({ agree: z.boolean(), name: z.string() });
+
+    const checkbox = el.shadowRoot!.querySelector("input[type='checkbox']")! as HTMLInputElement;
+    const label = el.shadowRoot!.querySelector("label")! as HTMLLabelElement;
+    const text = el.shadowRoot!.querySelector("wavelength-input")!;
+
+    expect(checkbox.id).toBe("form-agree");
+    expect(label.htmlFor).toBe("form-agree");
+    expect(text.getAttribute("id")).toBe("form-name");
+  });
 });

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -9,6 +9,7 @@ interface WavelengthFormElement extends HTMLElement {
   validate?: () => boolean;
   submitLabel?: string;
   submitButtonProps?: Record<string, unknown>;
+  idPrefix?: string;
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
@@ -27,6 +28,8 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   submitLabel?: string;
   /** Props forwarded to the internal wavelength-button */
   submitButtonProps?: Omit<WavelengthButtonProps, "children" | "onClick">;
+  /** Prefix applied to generated input IDs */
+  idPrefix?: string;
 
   /** Standard React props */
   className?: string;
@@ -56,7 +59,7 @@ function useStableCallback<F extends (...args: any[]) => any>(fn?: F) {
 }
 
 function WavelengthFormInner<T extends object = Record<string, unknown>>(
-  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel, submitButtonProps }: WavelengthFormProps<T>,
+  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel, submitButtonProps, idPrefix }: WavelengthFormProps<T>,
   ref: React.ForwardedRef<WavelengthFormRef<T>>,
 ) {
   const hostRef = useRef<WavelengthFormElement | null>(null);
@@ -75,7 +78,8 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     if (value) el.value = value as any;
     if (submitLabel !== undefined) el.submitLabel = submitLabel;
     if (submitButtonProps) el.submitButtonProps = submitButtonProps as any;
-  }, [schema, value, submitLabel, submitButtonProps]);
+    el.idPrefix = idPrefix as any;
+  }, [schema, value, submitLabel, submitButtonProps, idPrefix]);
 
   useEffect(() => {
     const el = hostRef.current;

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -52,6 +52,7 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
       control: "object",
       description: "Props forwarded to the internal wavelength-button",
     },
+    idPrefix: { control: "text", description: "Prefix applied to generated input IDs" },
   },
   args: {
     schema: sampleSchema,
@@ -74,6 +75,15 @@ export const CustomSubmitButton: Story = {
     value: { firstName: "Jane", lastName: "Doe" },
     submitLabel: "Register",
     submitButtonProps: { variant: "contained", colorOne: "#2e7d32", colorTwo: "#fff" },
+  },
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const WithIdPrefix: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    idPrefix: "person",
   },
   render: (args) => <WavelengthForm {...args} />,
 };


### PR DESCRIPTION
## Summary
- generate deterministic ids for inputs in `<wavelength-form>` and link checkbox labels
- allow custom `idPrefix` for both web component and React wrapper
- document and test id generation

## Testing
- `npm run test:jest`
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run lint` *(fails: prettier errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b714dbf7548325a512209063cf8289