### PR TITLE
feat: add optional title to WavelengthForm

### DIFF
--- a/apps/package/README.md
+++ b/apps/package/README.md
@@ -14,6 +14,11 @@ npm install @wavelengthusaf/components
 
 ## Release Notes
 
+### 3.3.8
+
+- 8/12/2025
+- Added optional `title` and `titleAlign` props to `WavelengthForm` for displaying a heading above the form.
+
 ### 3.3.7
 
 - 8/11/2025

--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -91,4 +91,17 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(label.htmlFor).toBe("test-agree");
     expect(text.getAttribute("id")).toBe("test-name");
   });
+
+  test("renders title with alignment", async () => {
+    const schema = z.object({ name: z.string() });
+    render(<WavelengthForm schema={schema} title="My Form" titleAlign="center" />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const heading = host.shadowRoot!.querySelector("h2") as HTMLElement;
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toBe("My Form");
+    expect(heading.style.textAlign).toBe("center");
+  });
 });

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -10,6 +10,8 @@ interface WavelengthFormElement extends HTMLElement {
   submitLabel?: string;
   submitButtonProps?: Record<string, unknown>;
   idPrefix?: string;
+  title: string;
+  titleAlign?: string;
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
@@ -30,6 +32,10 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   submitButtonProps?: Omit<WavelengthButtonProps, "children" | "onClick">;
   /** Prefix applied to generated input IDs */
   idPrefix?: string;
+  /** Optional heading text displayed above the form */
+  title?: string;
+  /** Alignment for the heading text (default: left) */
+  titleAlign?: React.CSSProperties["textAlign"];
 
   /** Standard React props */
   className?: string;
@@ -59,7 +65,7 @@ function useStableCallback<F extends (...args: any[]) => any>(fn?: F) {
 }
 
 function WavelengthFormInner<T extends object = Record<string, unknown>>(
-  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel, submitButtonProps, idPrefix }: WavelengthFormProps<T>,
+  { schema, value, className, style, onChange, onValid, onInvalid, submitLabel, submitButtonProps, idPrefix, title, titleAlign }: WavelengthFormProps<T>,
   ref: React.ForwardedRef<WavelengthFormRef<T>>,
 ) {
   const hostRef = useRef<WavelengthFormElement | null>(null);
@@ -79,7 +85,9 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     if (submitLabel !== undefined) el.submitLabel = submitLabel;
     if (submitButtonProps) el.submitButtonProps = submitButtonProps as any;
     el.idPrefix = idPrefix as any;
-  }, [schema, value, submitLabel, submitButtonProps, idPrefix]);
+    if (title !== undefined) el.title = title;
+    if (titleAlign !== undefined) el.titleAlign = titleAlign as any;
+  }, [schema, value, submitLabel, submitButtonProps, idPrefix, title, titleAlign]);
 
   useEffect(() => {
     const el = hostRef.current;

--- a/apps/package/src/types/global.d.ts
+++ b/apps/package/src/types/global.d.ts
@@ -44,6 +44,9 @@ declare namespace JSX {
 
     "wavelength-form": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
       "submit-label"?: string;
+      "id-prefix"?: string;
+      title?: string;
+      "title-align"?: string;
     };
 
     "wavelength-progress-bar": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -16,10 +16,12 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   private _submitLabel = "Submit";
   private _submitButtonProps: Record<string, unknown> = {};
   private _idPrefix = "";
+  private _title = "";
+  private _titleAlign: string = "left";
 
   static get observedAttributes() {
     // schema is a property, not an attribute
-    return ["submit-label", "id-prefix"];
+    return ["submit-label", "id-prefix", "title", "title-align"];
   }
 
   constructor() {
@@ -80,6 +82,30 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     return this._idPrefix || undefined;
   }
 
+  /** Heading text displayed above the form */
+  set title(v: string) {
+    this._title = v ?? "";
+    if (v === "") {
+      this.removeAttribute("title");
+    } else {
+      this.setAttribute("title", v);
+    }
+    this.render();
+  }
+  get title(): string {
+    return this._title;
+  }
+
+  /** CSS text-align value applied to the heading */
+  set titleAlign(v: string | undefined) {
+    this._titleAlign = v ?? "left";
+    this.setAttribute("title-align", this._titleAlign);
+    this.render();
+  }
+  get titleAlign(): string {
+    return this._titleAlign;
+  }
+
   /**
    * Imperative validation without submitting.
    * Returns true if the current form values are valid.
@@ -98,6 +124,12 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       this.render();
     } else if (name === "id-prefix") {
       this._idPrefix = value ?? "";
+      this.render();
+    } else if (name === "title") {
+      this._title = value ?? "";
+      this.render();
+    } else if (name === "title-align") {
+      this._titleAlign = value ?? "left";
       this.render();
     }
   }
@@ -344,6 +376,12 @@ export class WavelengthForm<T extends object> extends HTMLElement {
 
     // mount
     this._shadow.innerHTML = `<style>${css}</style>`;
+    if (this._title) {
+      const heading = document.createElement("h2");
+      heading.textContent = this._title;
+      heading.style.textAlign = this._titleAlign;
+      this._shadow.appendChild(heading);
+    }
     this._shadow.appendChild(form);
 
     // reapply existing error state if any (e.g., after re-render)

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -35,6 +35,9 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
             <code>submitButtonProps</code> to forward attributes to the internal
             <code>&lt;wavelength-button&gt;</code>.
           </p>
+          <p>
+            Provide a <code>title</code> to render a heading above the form and control its alignment with <code>titleAlign</code>.
+          </p>
           <h2>Example</h2>
           <Canvas />
           <h2>Props</h2>
@@ -53,6 +56,12 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
       description: "Props forwarded to the internal wavelength-button",
     },
     idPrefix: { control: "text", description: "Prefix applied to generated input IDs" },
+    title: { control: "text", description: "Heading text displayed above the form" },
+    titleAlign: {
+      control: "select",
+      options: ["left", "center", "right"],
+      description: "Alignment for the heading text",
+    },
   },
   args: {
     schema: sampleSchema,
@@ -84,6 +93,16 @@ export const WithIdPrefix: Story = {
     schema: sampleSchema,
     value: { firstName: "Jane", lastName: "Doe" },
     idPrefix: "person",
+  },
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const WithTitle: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    title: "Registration",
+    titleAlign: "center",
   },
   render: (args) => <WavelengthForm {...args} />,
 };


### PR DESCRIPTION
## Summary
- allow `wavelength-form` to render an optional heading with configurable alignment
- forward `title` and `titleAlign` through React wrapper and add story
- document new props and release notes

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run lint` *(fails: prettier formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7211a6bd08325a9305e60ef308565