### PR TITLE
feat: add placeholder support to zod forms

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -104,4 +104,28 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(heading.textContent).toBe("My Form");
     expect(heading.style.textAlign).toBe("center");
   });
+
+  test("uses placeholder from schema and mirrors label", async () => {
+    const schema = z.object({ name: z.string().describe("Your name") });
+    render(<WavelengthForm schema={schema} />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const input = host.shadowRoot!.querySelector("wavelength-input")!;
+    expect(input).toHaveAttribute("placeholder", "Your name");
+    expect(input).toHaveAttribute("label", "Your name");
+  });
+
+  test("placeholders prop overrides schema", async () => {
+    const schema = z.object({ name: z.string().describe("Schema") });
+    render(<WavelengthForm schema={schema} placeholders={{ name: "Override" }} />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const input = host.shadowRoot!.querySelector("wavelength-input")!;
+    expect(input).toHaveAttribute("placeholder", "Override");
+    expect(input).toHaveAttribute("label", "Override");
+  });
 });

--- a/apps/package/jest/zodToTextFields.test.ts
+++ b/apps/package/jest/zodToTextFields.test.ts
@@ -10,9 +10,9 @@ describe("zodToTextFields", () => {
     });
 
     expect(zodToTextFields(schema)).toEqual([
-      { name: "name", label: "Name", type: "text", required: true },
-      { name: "age", label: "Age", type: "number", required: true },
-      { name: "subscribed", label: "Subscribed", type: "checkbox", required: true },
+      { name: "name", label: "Name", type: "text", required: true, placeholder: "Name" },
+      { name: "age", label: "Age", type: "number", required: true, placeholder: "Age" },
+      { name: "subscribed", label: "Subscribed", type: "checkbox", required: true, placeholder: "Subscribed" },
     ]);
   });
 
@@ -24,9 +24,9 @@ describe("zodToTextFields", () => {
     });
 
     expect(zodToTextFields(schema)).toEqual([
-      { name: "title", label: "Title", type: "text", required: false },
-      { name: "count", label: "Count", type: "number", required: false },
-      { name: "active", label: "Active", type: "checkbox", required: false },
+      { name: "title", label: "Title", type: "text", required: false, placeholder: "Title" },
+      { name: "count", label: "Count", type: "number", required: false, placeholder: "Count" },
+      { name: "active", label: "Active", type: "checkbox", required: false, placeholder: "Active" },
     ]);
   });
 
@@ -43,7 +43,22 @@ describe("zodToTextFields", () => {
         required: true,
         minLength: 3,
         maxLength: 10,
+        placeholder: "Username",
       },
+    ]);
+  });
+
+  test("populates placeholders from meta or description", () => {
+    const schema = z.object({
+      meta: z.string().meta({ placeholder: "Meta" }),
+      desc: z.string().describe("Desc"),
+      none: z.string(),
+    });
+
+    expect(zodToTextFields(schema)).toEqual([
+      { name: "meta", label: "Meta", type: "text", required: true, placeholder: "Meta" },
+      { name: "desc", label: "Desc", type: "text", required: true, placeholder: "Desc" },
+      { name: "none", label: "None", type: "text", required: true, placeholder: "None" },
     ]);
   });
 

--- a/apps/package/src/form/zodToFields.ts
+++ b/apps/package/src/form/zodToFields.ts
@@ -61,6 +61,16 @@ export function zodToFields(schema: ZodObject<Shape>): FieldDef[] {
         required: typeof anyZt.isOptional === "function" ? !anyZt.isOptional() : true,
       };
 
+      const placeholder =
+        (typeof anyZt.meta === "function" ? anyZt.meta()?.placeholder : undefined) ??
+        anyZt?.description ??
+        anyZt?._def?.description ??
+        (typeof (core as any).meta === "function" ? (core as any).meta()?.placeholder : undefined) ??
+        (core as any)?.description ??
+        (core as any)?._def?.description ??
+        field.label;
+      field.placeholder = placeholder;
+
       if (type === "text") {
         const checks: any[] = (core as any)?._def?.checks ?? [];
         for (const chk of checks) {

--- a/apps/package/src/types/fields.ts
+++ b/apps/package/src/types/fields.ts
@@ -3,6 +3,7 @@ export type FieldType = "text" | "number" | "checkbox";
 export type FieldDef = {
   name: string;
   label: string;
+  placeholder?: string;
   type: FieldType;
   required?: boolean;
   minLength?: number;

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -305,7 +305,12 @@ export class WavelengthForm<T extends object> extends HTMLElement {
 
         input.setAttribute("data-name", f.name);
         input.setAttribute("name", f.name);
-        input.setAttribute("label", f.label);
+        if (f.placeholder !== undefined) {
+          input.setAttribute("placeholder", f.placeholder);
+          input.setAttribute("label", f.placeholder);
+        } else {
+          input.setAttribute("label", f.label);
+        }
         input.setAttribute("validation-type", "manual"); // form drives error visuals
         input.setAttribute("id", id);
         if (f.type === "number") {


### PR DESCRIPTION
## Summary
- support per-field placeholders in FieldDef and zodToFields
- propagate placeholders to wavelength-form and React wrapper
- add tests for placeholder handling and React overrides

## Testing
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_68b734449a7483258098ba160ec13bad