### PR TITLE
feat: add layout and width options to form

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -128,4 +128,18 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(input).toHaveAttribute("placeholder", "Override");
     expect(input).toHaveAttribute("label", "Override");
   });
+
+  test("forwards layout and formWidth", async () => {
+    const schema = z.object({ a: z.string(), b: z.string(), c: z.string() });
+    render(<WavelengthForm schema={schema} layout={[2, 1]} formWidth="350px" />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const rows = host.shadowRoot!.querySelectorAll(".field-row");
+    expect(rows.length).toBe(2);
+    expect(rows[0].children.length).toBe(2);
+    const form = host.shadowRoot!.querySelector("form") as HTMLFormElement;
+    expect(form.style.width).toBe("350px");
+  });
 });

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -101,4 +101,38 @@ describe("wavelength-form web component", () => {
     expect(label.htmlFor).toBe("form-agree");
     expect(text.getAttribute("id")).toBe("form-name");
   });
+
+  test("applies layout rows and columns", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.layout = [2, 1];
+    el.schema = z.object({ a: z.string(), b: z.string(), c: z.string() });
+
+    const rows = el.shadowRoot!.querySelectorAll(".field-row");
+    expect(rows.length).toBe(2);
+    expect(rows[0].children.length).toBe(2);
+    expect(rows[1].children.length).toBe(1);
+    expect((rows[0] as HTMLElement).style.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect((rows[1] as HTMLElement).style.gridTemplateColumns).toBe("repeat(1, 1fr)");
+  });
+
+  test("defaults to single column when layout omitted", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({ a: z.string(), b: z.string() });
+
+    const rows = el.shadowRoot!.querySelectorAll(".field-row");
+    expect(rows.length).toBe(2);
+    expect(Array.from(rows).every((r) => (r as HTMLElement).children.length === 1)).toBe(true);
+  });
+
+  test("applies formWidth style", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.formWidth = "300px";
+    el.schema = z.object({ a: z.string() });
+
+    const form = el.shadowRoot!.querySelector("form") as HTMLFormElement;
+    expect(form.style.width).toBe("300px");
+  });
 });

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -12,6 +12,8 @@ interface WavelengthFormElement extends HTMLElement {
   idPrefix?: string;
   title: string;
   titleAlign?: string;
+  formWidth?: string;
+  layout?: number[];
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
@@ -38,6 +40,10 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   titleAlign?: React.CSSProperties["textAlign"];
   /** Per-field placeholder overrides */
   placeholders?: Partial<Record<keyof T & string, string>>;
+  /** CSS width applied to the underlying form element */
+  formWidth?: string;
+  /** Array defining how many fields appear in each row */
+  layout?: number[];
 
   /** Standard React props */
   className?: string;
@@ -84,6 +90,8 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     title,
     titleAlign,
     placeholders,
+    formWidth,
+    layout,
   } = props;
   const hostRef = useRef<WavelengthFormElement | null>(null);
 
@@ -121,7 +129,9 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(
     el.idPrefix = idPrefix as any;
     if (title !== undefined) el.title = title;
     if (titleAlign !== undefined) el.titleAlign = titleAlign as any;
-  }, [schema, value, submitLabel, submitButtonProps, idPrefix, title, titleAlign, placeholders]);
+    if (formWidth !== undefined) el.formWidth = formWidth;
+    if (layout !== undefined) el.layout = layout;
+  }, [schema, value, submitLabel, submitButtonProps, idPrefix, title, titleAlign, placeholders, formWidth, layout]);
 
   useEffect(() => {
     const el = hostRef.current;

--- a/apps/package/src/types/global.d.ts
+++ b/apps/package/src/types/global.d.ts
@@ -47,6 +47,7 @@ declare namespace JSX {
       "id-prefix"?: string;
       title?: string;
       "title-align"?: string;
+      "form-width"?: string;
     };
 
     "wavelength-progress-bar": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -62,6 +62,8 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
       options: ["left", "center", "right"],
       description: "Alignment for the heading text",
     },
+    formWidth: { control: "text", description: "CSS width applied to the form" },
+    layout: { control: "object", description: "Array of column counts per row" },
   },
   args: {
     schema: sampleSchema,
@@ -103,6 +105,16 @@ export const WithTitle: Story = {
     value: { firstName: "Jane", lastName: "Doe" },
     title: "Registration",
     titleAlign: "center",
+  },
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const WithLayout: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    layout: [2],
+    formWidth: "400px",
   },
   render: (args) => <WavelengthForm {...args} />,
 };


### PR DESCRIPTION
## Summary
- allow WavelengthForm to arrange fields in grid rows via new `layout` prop
- add optional `formWidth` control and forward through React wrapper and Storybook
- test row/column placement and width behavior

## Testing
- `npm run test:jest`
- `npm run test:cypress` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b73887473883259a468f3e31bb3fc6