### PR TITLE
feat(form): add back navigation and submit toggle

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -142,4 +142,14 @@ describe("WavelengthForm (React Wrapper)", () => {
     const form = host.shadowRoot!.querySelector("form") as HTMLFormElement;
     expect(form.style.width).toBe("350px");
   });
+
+  test("onBack fires from custom event", () => {
+    const schema = z.object({ name: z.string() });
+    const onBack = jest.fn();
+    render(<WavelengthForm schema={schema} backLabel="Back" onBack={onBack} />);
+
+    const host = document.querySelector("wavelength-form")!;
+    host.dispatchEvent(new CustomEvent("form-back"));
+    expect(onBack).toHaveBeenCalled();
+  });
 });

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -135,4 +135,26 @@ describe("wavelength-form web component", () => {
     const form = el.shadowRoot!.querySelector("form") as HTMLFormElement;
     expect(form.style.width).toBe("300px");
   });
+
+  test("can hide submit button", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.showSubmit = false;
+    el.schema = z.object({ name: z.string() });
+    const button = el.shadowRoot!.querySelector("wavelength-button");
+    expect(button).toBeNull();
+  });
+
+  test("emits form-back when back button clicked", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.backLabel = "Back";
+    el.schema = z.object({ name: z.string() });
+
+    const handler = jest.fn();
+    el.addEventListener("form-back", handler);
+    const back = el.shadowRoot!.querySelector("button")!;
+    fireEvent.click(back);
+    expect(handler).toHaveBeenCalled();
+  });
 });

--- a/apps/package/src/types/global.d.ts
+++ b/apps/package/src/types/global.d.ts
@@ -48,6 +48,8 @@ declare namespace JSX {
       title?: string;
       "title-align"?: string;
       "form-width"?: string;
+      "show-submit"?: boolean;
+      "back-label"?: string;
     };
 
     "wavelength-progress-bar": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -55,6 +55,9 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
       control: "object",
       description: "Props forwarded to the internal wavelength-button",
     },
+    showSubmit: { control: "boolean", description: "Toggle internal submit button" },
+    backLabel: { control: "text", description: "Label for a back button" },
+    backButtonProps: { control: "object", description: "Props for the back button" },
     idPrefix: { control: "text", description: "Prefix applied to generated input IDs" },
     title: { control: "text", description: "Heading text displayed above the form" },
     titleAlign: {
@@ -117,4 +120,22 @@ export const WithLayout: Story = {
     formWidth: "400px",
   },
   render: (args) => <WavelengthForm {...args} />,
+};
+
+export const WithoutSubmitButton: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    showSubmit: false,
+  },
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const WithBackButton: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    backLabel: "Back",
+  },
+  render: (args) => <WavelengthForm {...args} onBack={() => console.log("back")} />,
 };


### PR DESCRIPTION
## Summary
- allow `<wavelength-form>` to hide the submit button via `showSubmit`
- add optional back button that emits `form-back` events
- expose new options and callbacks in React wrapper and Storybook

## Testing
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_68bef7177c288325b001d6abc04b619b