### PR TITLE
Use wavelength-button in wavelength-form

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import WavelengthForm from "../src/components/forms/WavelengthForm";
 import "../src/web-components/wavelength-form";
 import "../src/web-components/wavelength-input";
+import "../src/web-components/wavelength-button";
 
 // This test focuses on the React wrapper receiving the correct
 // detail payloads from the custom events.
@@ -57,7 +58,7 @@ describe("WavelengthForm (React Wrapper)", () => {
     // wait for effects
     await new Promise((r) => setTimeout(r, 0));
 
-    const button = host.shadowRoot.querySelector("button");
+    const button = host.shadowRoot.querySelector("wavelength-button");
     expect(button).toHaveAttribute("id", "go-btn");
     expect(button).toHaveAttribute("disabled");
     expect(button.textContent).toContain("Go");
@@ -69,7 +70,7 @@ describe("WavelengthForm (React Wrapper)", () => {
 
     await new Promise((r) => setTimeout(r, 0));
     let host = document.querySelector("wavelength-form")!;
-    expect(host.shadowRoot!.querySelectorAll("button").length).toBe(0);
+    expect(host.shadowRoot!.querySelectorAll("wavelength-button").length).toBe(0);
 
     rerender(
       <WavelengthForm
@@ -81,7 +82,7 @@ describe("WavelengthForm (React Wrapper)", () => {
     );
     await new Promise((r) => setTimeout(r, 0));
     host = document.querySelector("wavelength-form")!;
-    expect(host.shadowRoot!.querySelectorAll("button").length).toBe(3);
+    expect(host.shadowRoot!.querySelectorAll("wavelength-button").length).toBe(3);
   });
 
   test("buttons emit events and apply props", async () => {
@@ -103,9 +104,9 @@ describe("WavelengthForm (React Wrapper)", () => {
     host.addEventListener("go-center", () => seen.push("center"));
     host.addEventListener("go-submit", () => seen.push("submit"));
 
-    const left = host.shadowRoot!.getElementById("left") as HTMLButtonElement;
-    const center = host.shadowRoot!.getElementById("center") as HTMLButtonElement;
-    const right = host.shadowRoot!.getElementById("right") as HTMLButtonElement;
+    const left = host.shadowRoot!.getElementById("left") as HTMLElement;
+    const center = host.shadowRoot!.getElementById("center") as HTMLElement;
+    const right = host.shadowRoot!.getElementById("right") as HTMLElement;
 
     left.click();
     center.click();

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/dom";
 import { z } from "zod";
 import "../../src/web-components/wavelength-form";
 import "../../src/web-components/wavelength-input";
+import "../../src/web-components/wavelength-button";
 
 describe("wavelength-form web component", () => {
   afterEach(() => {
@@ -25,7 +26,7 @@ describe("wavelength-form web component", () => {
     fireEvent(input, new CustomEvent("inputChange", { detail: { value: "A" } }));
     expect(change).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
 
-    const button = el.shadowRoot!.querySelector("button")!;
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(button);
     expect(valid).toHaveBeenCalledWith({ value: { name: "A" }, issues: [] });
   });
@@ -39,7 +40,7 @@ describe("wavelength-form web component", () => {
     el.addEventListener("form-invalid", (e: Event) => invalid((e as CustomEvent).detail));
 
     el.rightButton = { label: "Submit" };
-    const button = el.shadowRoot!.querySelector("button")!;
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(button);
     expect(invalid).toHaveBeenCalled();
     expect(invalid.mock.calls[0][0].issues.length).toBeGreaterThan(0);
@@ -57,7 +58,7 @@ describe("wavelength-form web component", () => {
     });
 
     el.rightButton = { label: "Submit" };
-    const button = el.shadowRoot!.querySelector("button")!;
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(button);
 
     const input = el.shadowRoot!.querySelector("wavelength-input") as any;
@@ -88,7 +89,7 @@ describe("wavelength-form web component", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;
     el.rightButton = { label: "Go" };
-    const button = el.shadowRoot!.querySelector("button")!;
+    const button = el.shadowRoot!.querySelector("wavelength-button")!;
     expect(button.textContent).toBe("Go");
   });
 
@@ -145,7 +146,7 @@ describe("wavelength-form web component", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;
     el.schema = z.object({ name: z.string() });
-    const button = el.shadowRoot!.querySelector("button");
+    const button = el.shadowRoot!.querySelector("wavelength-button");
     expect(button).toBeNull();
   });
 
@@ -157,7 +158,7 @@ describe("wavelength-form web component", () => {
 
     const handler = jest.fn();
     el.addEventListener("form-back", handler);
-    const back = el.shadowRoot!.querySelector("button")!;
+    const back = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(back);
     expect(handler).toHaveBeenCalled();
   });

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -7,7 +7,7 @@ type Shape = ZodRawShape;
 
 type ButtonConfig = {
   label?: string;
-  buttonProps?: Partial<HTMLButtonElement>;
+  buttonProps?: Record<string, any>;
   eventName?: string;
 };
 
@@ -432,13 +432,23 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     rightSlot.className = "right";
 
     const buildButton = (cfg: ButtonConfig, defaultEvent: string, defaultType: "button" | "submit") => {
-      const btn = document.createElement("button");
+      const btn = document.createElement("wavelength-button");
+      const type = (cfg.buttonProps?.type as string) ?? defaultType;
+      if (cfg.buttonProps) {
+        for (const [key, value] of Object.entries(cfg.buttonProps)) {
+          if (key === "type") continue;
+          if (value !== undefined) btn.setAttribute(key, String(value));
+        }
+      }
+      btn.setAttribute("type", type);
       if (cfg.label) btn.textContent = cfg.label;
-      if (cfg.buttonProps) Object.assign(btn, cfg.buttonProps);
-      btn.type = cfg.buttonProps?.type ?? defaultType;
       btn.addEventListener("click", (e) => {
-        if (btn.type !== "submit") e.preventDefault();
         const ev = cfg.eventName ?? defaultEvent;
+        if (type === "submit") {
+          form.requestSubmit();
+        } else {
+          e.preventDefault();
+        }
         this.dispatchEvent(new CustomEvent(ev));
       });
       return btn;


### PR DESCRIPTION
## Summary
- build buttons using `<wavelength-button>` and map `buttonProps` to attributes
- call `form.requestSubmit()` for custom submit buttons
- adjust tests for new button element

## Testing
- `CI=true npm run test:jest`
- `npm run lint` *(fails: prettier formatting errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c0439921188325a9386e9cc8f06704