### PR TITLE
docs: showcase WavelengthForm button attributes

### DIFF
--- a/apps/package/README.md
+++ b/apps/package/README.md
@@ -16,21 +16,34 @@ npm install @wavelengthusaf/components
 
 `WavelengthForm` exposes configurable action buttons. Provide a `leftButton`,
 `centerButton`, and/or `rightButton` object with a `label`, optional
-`buttonProps` passed to the underlying `<button>`, and an optional `eventName`
-to customize the emitted event. Default events are `form-back`, `form-center`,
-and `form-submit`.
+`buttonProps` forwarded as attributes to the underlying `<wavelength-button>`,
+and an optional `eventName` to customize the emitted event. Default events are
+`form-back`, `form-center`, and `form-submit`.
 
 ```tsx
 <WavelengthForm
   schema={schema}
-  leftButton={{ label: "Back", buttonProps: { id: "back-btn" } }}
-  centerButton={{ label: "Save", buttonProps: { id: "save-btn", type: "button" } }}
-  rightButton={{ label: "Next", buttonProps: { id: "next-btn" } }}
+  leftButton={{
+    label: "Back",
+    buttonProps: { id: "back-btn", variant: "text", size: "small" },
+  }}
+  centerButton={{
+    label: "Save",
+    buttonProps: { id: "save-btn", type: "button", variant: "outlined", size: "medium" },
+  }}
+  rightButton={{
+    label: "Next",
+    buttonProps: { id: "next-btn", variant: "contained", size: "large" },
+  }}
   onBack={() => console.log("back")}
   onCenter={() => console.log("center")}
   onSubmit={() => console.log("submit")}
 />
 ```
+
+The `buttonProps` object is forwarded as attributes to
+`<wavelength-button>`, allowing you to customize each button via properties
+like `variant` or `size`.
 
 ## Release Notes
 

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -33,7 +33,9 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
           <p>
             Optional action buttons can be added via the <code>leftButton</code>,
             <code>centerButton</code>, and <code>rightButton</code> props. Each accepts a
-            label, standard button props, and an optional custom event name.
+            label, optional <code>buttonProps</code> forwarded to the underlying
+            <code>&lt;wavelength-button&gt;</code> (for example, <code>variant</code> or
+            <code>size</code>), and an optional custom event name.
           </p>
           <p>
             Provide a <code>title</code> to render a heading above the form and control its alignment with <code>titleAlign</code>.
@@ -82,7 +84,10 @@ export const CustomRightButton: Story = {
   args: {
     schema: sampleSchema,
     value: { firstName: "Jane", lastName: "Doe" },
-    rightButton: { label: "Register", buttonProps: { id: "register-btn" } },
+    rightButton: {
+      label: "Register",
+      buttonProps: { id: "register-btn", variant: "contained", size: "large" },
+    },
   },
   render: (args) => <WavelengthForm {...args} />,
 };
@@ -128,7 +133,10 @@ export const WithBackButton: Story = {
   args: {
     schema: sampleSchema,
     value: { firstName: "Jane", lastName: "Doe" },
-    leftButton: { label: "Back", buttonProps: { id: "back-btn" } },
+    leftButton: {
+      label: "Back",
+      buttonProps: { id: "back-btn", variant: "text", size: "small" },
+    },
   },
   render: (args) => <WavelengthForm {...args} onBack={() => console.log("back")} />,
 };
@@ -137,7 +145,10 @@ export const WithCenterButton: Story = {
   args: {
     schema: sampleSchema,
     value: { firstName: "Jane", lastName: "Doe" },
-    centerButton: { label: "Help", buttonProps: { id: "help-btn" } },
+    centerButton: {
+      label: "Help",
+      buttonProps: { id: "help-btn", variant: "outlined", size: "medium" },
+    },
   },
   render: (args) => <WavelengthForm {...args} onCenter={() => console.log("center")} />,
 };


### PR DESCRIPTION
## Summary
- document that buttonProps are forwarded to `<wavelength-button>` and show sample variant and size usage
- update WavelengthForm Storybook docs and stories to demonstrate left, center, and right buttons with variant and size attributes

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b1ab9ec83259ee557be71ecdbe6