### PR TITLE
feat: make wavelength input responsive

### DIFF
--- a/apps/package/src/web-components/wavelength-input.ts
+++ b/apps/package/src/web-components/wavelength-input.ts
@@ -1,12 +1,13 @@
 const template = document.createElement("template");
 template.innerHTML = `
-<style>  
-  :host {  
-    display: inline-block;  
-    font-family: sans-serif;  
-    --wavelength-container-background: #f8f8f8;  
-    --wavelength-label-background: #ffffff;  
-  }  
+<style>
+  :host {
+    display: block;
+    width: 100%;
+    font-family: sans-serif;
+    --wavelength-container-background: #f8f8f8;
+    --wavelength-label-background: #ffffff;
+  }
 
   .field-wrapper {  
     position: relative;  
@@ -498,7 +499,8 @@ export class WavelengthInput extends HTMLElement {
   }
 
   private _applyLayout() {
-    const width = this.getAttribute("width") || "320px";
+    const widthAttr = this.getAttribute("width");
+    const width = widthAttr || "100%";
     const rawPadding = this.getAttribute("padding") || "16.5px 14px";
 
     const paddingParts = rawPadding.trim().split(/\s+/);
@@ -521,8 +523,8 @@ export class WavelengthInput extends HTMLElement {
         leftPaddingPx = 14;
     }
 
-    const parsedWidth = parseInt(width, 10);
-    const helperWidth = `${parsedWidth - leftPaddingPx}px`;
+    const isNumericWidth = widthAttr ? /^\d+(px)?$/.test(widthAttr.trim()) : false;
+    const helperWidth = isNumericWidth ? `${parseInt(widthAttr!, 10) - leftPaddingPx}px` : `calc(${width} - ${leftPaddingPx}px)`;
 
     this.inputEl.style.width = width;
     this.inputEl.style.padding = rawPadding;


### PR DESCRIPTION
## Summary
- default wavelength-input host to full-width block display
- compute layout widths dynamically for full grid responsiveness

## Testing
- `npm test` *(fails: Your system is missing the dependency: Xvfb)*
- `npm run lint` *(fails: Prettier errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c06bd730b08325919bd16b81a11793