### PR TITLE
feat: allow global input props in WavelengthForm

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -137,6 +137,18 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(seen).toEqual(["back", "center", "submit"]);
   });
 
+  test("forwards inputProps to inputs", async () => {
+    const schema = z.object({ name: z.string() });
+    render(<WavelengthForm schema={schema} inputProps={{ width: "150px", "data-test": "foo" }} />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const input = host.shadowRoot!.querySelector("wavelength-input")!;
+    expect(input).toHaveAttribute("width", "150px");
+    expect(input).toHaveAttribute("data-test", "foo");
+  });
+
   test("propagates container background to inputs", async () => {
     const schema = z.object({ name: z.string() });
     const color = "rgb(1, 2, 3)";

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -122,6 +122,19 @@ describe("wavelength-form web component", () => {
     expect((rows[1] as HTMLElement).style.gridTemplateColumns).toBe("repeat(1, 1fr)");
   });
 
+  test("applies inputProps to all inputs", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({ a: z.string(), b: z.string() });
+    el.inputProps = { width: "120px", "data-test": "shared" };
+
+    const inputs = el.shadowRoot!.querySelectorAll("wavelength-input");
+    inputs.forEach((input) => {
+      expect((input as HTMLElement).getAttribute("width")).toBe("120px");
+      expect((input as HTMLElement).getAttribute("data-test")).toBe("shared");
+    });
+  });
+
   test("defaults to single column when layout omitted", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -13,6 +13,11 @@ export interface ButtonConfig {
   eventName?: string;
 }
 
+/** Attributes passed through to each generated `wavelength-input` */
+export interface WavelengthInputAttributes extends React.HTMLAttributes<HTMLElement> {
+  [key: string]: any;
+}
+
 interface WavelengthFormElement extends HTMLElement {
   schema?: unknown;
   value?: Record<string, unknown>;
@@ -20,6 +25,7 @@ interface WavelengthFormElement extends HTMLElement {
   leftButton?: ButtonConfig;
   centerButton?: ButtonConfig;
   rightButton?: ButtonConfig;
+  inputProps?: WavelengthInputAttributes;
   idPrefix?: string;
   title: string;
   titleAlign?: string;
@@ -45,6 +51,8 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   centerButton?: ButtonConfig;
   /** Configuration for an optional right-aligned button */
   rightButton?: ButtonConfig;
+  /** Props applied to each generated WavelengthInput */
+  inputProps?: WavelengthInputAttributes;
   /** Prefix applied to generated input IDs */
   idPrefix?: string;
   /** Optional heading text displayed above the form */
@@ -103,6 +111,7 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     leftButton,
     centerButton,
     rightButton,
+    inputProps,
     idPrefix,
     title,
     titleAlign,
@@ -150,12 +159,26 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     if (leftButton !== undefined) el.leftButton = leftButton as any;
     if (centerButton !== undefined) el.centerButton = centerButton as any;
     if (rightButton !== undefined) el.rightButton = rightButton as any;
+    if (inputProps !== undefined) el.inputProps = inputProps as any;
     el.idPrefix = idPrefix as any;
     if (title !== undefined) el.title = title;
     if (titleAlign !== undefined) el.titleAlign = titleAlign as any;
     if (formWidth !== undefined) el.formWidth = formWidth;
     if (layout !== undefined) el.layout = layout;
-  }, [schema, value, leftButton, centerButton, rightButton, idPrefix, title, titleAlign, placeholders, formWidth, layout]);
+  }, [
+    schema,
+    value,
+    leftButton,
+    centerButton,
+    rightButton,
+    inputProps,
+    idPrefix,
+    title,
+    titleAlign,
+    placeholders,
+    formWidth,
+    layout,
+  ]);
 
   useEffect(() => {
     const el = hostRef.current;

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -21,6 +21,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   private _leftButton?: ButtonConfig;
   private _centerButton?: ButtonConfig;
   private _rightButton?: ButtonConfig;
+  private _inputProps: Record<string, any> = {};
   private _idPrefix = "";
   private _title = "";
   private _titleAlign: string = "left";
@@ -88,6 +89,14 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   }
   get rightButton(): ButtonConfig | undefined {
     return this._rightButton;
+  }
+
+  set inputProps(v: Record<string, any> | undefined) {
+    this._inputProps = v ?? {};
+    this.render();
+  }
+  get inputProps(): Record<string, any> | undefined {
+    return this._inputProps;
   }
 
   set idPrefix(v: string | undefined) {
@@ -373,6 +382,12 @@ export class WavelengthForm<T extends object> extends HTMLElement {
             setAttribute: (k: string, v?: string) => void;
             removeAttribute: (k: string) => void;
           };
+
+          if (this._inputProps) {
+            for (const [key, value] of Object.entries(this._inputProps)) {
+              if (value !== undefined) input.setAttribute(key, String(value));
+            }
+          }
 
           input.setAttribute("data-name", f.name);
           input.setAttribute("name", f.name);

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -55,6 +55,7 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
     leftButton: { control: "object", description: "Config for left-aligned button" },
     centerButton: { control: "object", description: "Config for center-aligned button" },
     rightButton: { control: "object", description: "Config for right-aligned button" },
+    inputProps: { control: "object", description: "Props applied to each WavelengthInput" },
     idPrefix: { control: "text", description: "Prefix applied to generated input IDs" },
     title: { control: "text", description: "Heading text displayed above the form" },
     titleAlign: {
@@ -117,6 +118,15 @@ export const WithLayout: Story = {
     value: { firstName: "Jane", lastName: "Doe" },
     layout: [2],
     formWidth: "400px",
+  },
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const WithInputProps: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
+    inputProps: { width: "300px", "data-test": "story" },
   },
   render: (args) => <WavelengthForm {...args} />,
 };


### PR DESCRIPTION
## Summary
- add `inputProps` to WavelengthForm React wrapper so callers can pass attributes to all generated inputs
- support `inputProps` in `<wavelength-form>` web component and apply props to each internal `<wavelength-input>`
- document and test the new capability

## Testing
- `npm test` *(fails: <wavelength-input> respects helper color only when not in error, WavelengthInput defaults to required message when forceError without errorMessage, WavelengthInput uses provided errorMessage when present with forceError, wavelength-form web component renders multiple error messages)*

------
https://chatgpt.com/codex/tasks/task_e_68c1862f655c8325866f7c1729408f90