### PR TITLE
feat: format camelCase labels

### DIFF
--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -9,6 +9,22 @@ describe("wavelength-form web component", () => {
     document.body.innerHTML = "";
   });
 
+  test("formats camelCase keys into spaced labels", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.schema = z.object({
+      firstName: z.string(),
+      middleName: z.string(),
+      lastName: z.string(),
+    });
+
+    const inputs = el.shadowRoot!.querySelectorAll("wavelength-input");
+    const labels = Array.from(inputs).map((i) => (i as HTMLElement).getAttribute("label"));
+    const placeholders = Array.from(inputs).map((i) => (i as HTMLElement).getAttribute("placeholder"));
+    expect(labels).toEqual(["First Name", "Middle Name", "Last Name"]);
+    expect(placeholders).toEqual(["First Name", "Middle Name", "Last Name"]);
+  });
+
   test("emits change and valid events", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;

--- a/apps/package/src/form/zodToFields.ts
+++ b/apps/package/src/form/zodToFields.ts
@@ -4,6 +4,13 @@ import { FieldDef } from "../types/fields";
 
 type Shape = ZodRawShape;
 
+function camelToPascalLabel(name: string): string {
+  return name
+    .replace(/([A-Z])/g, " $1")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
 /**
  * Unwrap common Zod wrappers (optional/nullable/default/effects)
  * without relying on deprecated typings. We intentionally use `any`
@@ -56,7 +63,7 @@ export function zodToFields(schema: ZodObject<Shape>): FieldDef[] {
       const anyZt: any = zt;
       const field: FieldDef = {
         name,
-        label: name.charAt(0).toUpperCase() + name.slice(1),
+        label: camelToPascalLabel(name),
         type,
         required: typeof anyZt.isOptional === "function" ? !anyZt.isOptional() : true,
       };


### PR DESCRIPTION
## Summary
- add camelToPascalLabel helper to create human-friendly labels from camelCase keys
- use helper so default placeholders and labels are formatted
- test that camelCase schema keys render inputs with spaced labels

## Testing
- `npm run test:jest` (fails: <wavelength-input> helper color, wavelength-form multiple error messages, WavelengthInput wrapper, Validator import)
- `npm run test:cypress` (fails: missing Xvfb)


------
https://chatgpt.com/codex/tasks/task_e_68c1d66fbdac83259f7fc47b4620314f