### PR TITLE
Prefix generated input names alongside IDs

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -179,8 +179,10 @@ describe("WavelengthForm (React Wrapper)", () => {
     const text = host.shadowRoot!.querySelector("wavelength-input")!;
 
     expect(checkbox.id).toBe("test-agree");
+    expect(checkbox.name).toBe("test-agree");
     expect(label.htmlFor).toBe("test-agree");
     expect(text.getAttribute("id")).toBe("test-name");
+    expect(text.getAttribute("name")).toBe("test-name");
   });
 
   test("renders title with alignment", async () => {

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -120,8 +120,10 @@ describe("wavelength-form web component", () => {
     const text = el.shadowRoot!.querySelector("wavelength-input")!;
 
     expect(checkbox.id).toBe("form-agree");
+    expect(checkbox.name).toBe("form-agree");
     expect(label.htmlFor).toBe("form-agree");
     expect(text.getAttribute("id")).toBe("form-name");
+    expect(text.getAttribute("name")).toBe("form-name");
   });
 
   test("applies layout rows and columns", () => {

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -53,7 +53,7 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   rightButton?: ButtonConfig;
   /** Props applied to each generated WavelengthInput */
   inputProps?: WavelengthInputAttributes;
-  /** Prefix applied to generated input IDs */
+  /** Prefix applied to generated input IDs and names */
   idPrefix?: string;
   /** Optional heading text displayed above the form */
   title?: string;

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -353,14 +353,14 @@ export class WavelengthForm<T extends object> extends HTMLElement {
         const f = this._fields[fieldIndex++];
         const cell = document.createElement("div");
         cell.className = f.type === "checkbox" ? "row checkbox-row" : "row";
-        const id = this._idPrefix ? `${this._idPrefix}-${f.name}` : f.name;
+        const fieldId = this._idPrefix ? `${this._idPrefix}-${f.name}` : f.name;
 
         if (f.type === "checkbox") {
           const input = document.createElement("input");
           input.type = "checkbox";
-          input.id = id;
+          input.id = fieldId;
           input.setAttribute("data-name", f.name);
-          input.name = f.name;
+          input.name = fieldId;
           if (this._value[f.name] !== undefined) {
             input.checked = Boolean(this._value[f.name]);
           }
@@ -371,7 +371,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
           input.addEventListener("blur", () => this.onBlur(f.name));
 
           const label = document.createElement("label");
-          label.htmlFor = id;
+          label.htmlFor = fieldId;
           label.textContent = f.label;
 
           cell.appendChild(input);
@@ -390,7 +390,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
           }
 
           input.setAttribute("data-name", f.name);
-          input.setAttribute("name", f.name);
+          input.setAttribute("name", fieldId);
           if (f.placeholder !== undefined) {
             input.setAttribute("placeholder", f.placeholder);
             input.setAttribute("label", f.placeholder);
@@ -398,7 +398,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
             input.setAttribute("label", f.label);
           }
           input.setAttribute("validation-type", "manual"); // form drives error visuals
-          input.setAttribute("id", id);
+          input.setAttribute("id", fieldId);
           if (f.type === "number") {
             input.setAttribute("input-type", "number");
           }

--- a/apps/testbed/src/stories/Form.stories.tsx
+++ b/apps/testbed/src/stories/Form.stories.tsx
@@ -93,7 +93,7 @@ const sampleSchema = z.object({
     centerButton: { control: "object", description: "Config for center-aligned button" },
     rightButton: { control: "object", description: "Config for right-aligned button" },
     inputProps: { control: "object", description: "Props applied to each WavelengthInput" },
-    idPrefix: { control: "text", description: "Prefix applied to generated input IDs" },
+    idPrefix: { control: "text", description: "Prefix applied to generated input IDs and names" },
     title: { control: "text", description: "Heading text displayed above the form" },
     titleAlign: {
       control: "select",

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -56,7 +56,7 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
     centerButton: { control: "object", description: "Config for center-aligned button" },
     rightButton: { control: "object", description: "Config for right-aligned button" },
     inputProps: { control: "object", description: "Props applied to each WavelengthInput" },
-    idPrefix: { control: "text", description: "Prefix applied to generated input IDs" },
+    idPrefix: { control: "text", description: "Prefix applied to generated input IDs and names" },
     title: { control: "text", description: "Heading text displayed above the form" },
     titleAlign: {
       control: "select",


### PR DESCRIPTION
## Summary
- derive a single fieldId for each generated field
- prefix input `name` attributes alongside ids
- update docs and stories to note new behavior

## Testing
- `cd apps/package && npx jest jest/web-components/wavelength-form.test.ts -t "generates ids and links checkbox labels" --runInBand`
- `cd apps/package && npx jest jest/WavelengthForm.test.tsx -t "applies idPrefix to generated inputs" --runInBand`
- `npm run test:jest` *(fails: <wavelength-input> respects helper color only when not in error; wavelength-form web component renders multiple error messages; WavelengthInput defaults to required message when forceError without errorMessage; WavelengthInput uses provided errorMessage when present with forceError; Validator test suite cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d5eaa2c0832589f8e7a20701835b