### PR TITLE
feat: add titleColor to WavelengthForm

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -198,6 +198,18 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(heading.style.textAlign).toBe("center");
   });
 
+  test("renders title with color", async () => {
+    const schema = z.object({ name: z.string() });
+    render(<WavelengthForm schema={schema} title="My Form" titleColor="red" />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const heading = host.shadowRoot!.querySelector("h2") as HTMLElement;
+    expect(heading).toBeInTheDocument();
+    expect(heading.style.color).toBe("red");
+  });
+
   test("uses placeholder from schema and mirrors label", async () => {
     const schema = z.object({ name: z.string().describe("Your name") });
     render(<WavelengthForm schema={schema} />);

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -173,6 +173,14 @@ describe("wavelength-form web component", () => {
     expect(form.style.width).toBe("300px");
   });
 
+  test("applies title-color style to heading", () => {
+    document.body.innerHTML = `<wavelength-form title="My Form" title-color="blue"></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    const heading = el.shadowRoot!.querySelector("h2") as HTMLElement;
+    expect(heading).not.toBeNull();
+    expect(heading.style.color).toBe("blue");
+  });
+
   test("can hide submit button", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -29,6 +29,7 @@ interface WavelengthFormElement extends HTMLElement {
   idPrefix?: string;
   title: string;
   titleAlign?: string;
+  titleColor?: string;
   formWidth?: string;
   layout?: number[];
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
@@ -59,6 +60,8 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   title?: string;
   /** Alignment for the heading text (default: left) */
   titleAlign?: React.CSSProperties["textAlign"];
+  /** Color for the heading text */
+  titleColor?: React.CSSProperties["color"];
   /** Per-field placeholder overrides */
   placeholders?: Partial<Record<keyof T & string, string>>;
   /** CSS width applied to the underlying form element */
@@ -115,6 +118,7 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     idPrefix,
     title,
     titleAlign,
+    titleColor,
     placeholders,
     formWidth,
     layout,
@@ -163,6 +167,7 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     el.idPrefix = idPrefix as any;
     if (title !== undefined) el.title = title;
     if (titleAlign !== undefined) el.titleAlign = titleAlign as any;
+    if (titleColor !== undefined) el.titleColor = titleColor as any;
     if (formWidth !== undefined) el.formWidth = formWidth;
     if (layout !== undefined) el.layout = layout;
   }, [
@@ -175,6 +180,7 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     idPrefix,
     title,
     titleAlign,
+    titleColor,
     placeholders,
     formWidth,
     layout,

--- a/apps/package/src/types/global.d.ts
+++ b/apps/package/src/types/global.d.ts
@@ -46,6 +46,7 @@ declare namespace JSX {
       "id-prefix"?: string;
       title?: string;
       "title-align"?: string;
+      "title-color"?: string;
       "form-width"?: string;
     };
 

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -25,12 +25,13 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   private _idPrefix = "";
   private _title = "";
   private _titleAlign: string = "left";
+  private _titleColor = "";
   private _formWidth: string = "";
   private _layout?: number[];
 
   static get observedAttributes() {
     // schema is a property, not an attribute
-    return ["id-prefix", "title", "title-align", "form-width"];
+    return ["id-prefix", "title", "title-align", "title-color", "form-width"];
   }
 
   constructor() {
@@ -131,6 +132,20 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     return this._titleAlign;
   }
 
+  /** Color applied to the heading text */
+  set titleColor(v: string | undefined) {
+    this._titleColor = v ?? "";
+    if (v === undefined) {
+      this.removeAttribute("title-color");
+    } else {
+      this.setAttribute("title-color", this._titleColor);
+    }
+    this.render();
+  }
+  get titleColor(): string | undefined {
+    return this._titleColor || undefined;
+  }
+
   /** Width applied to the form element */
   set formWidth(v: string | undefined) {
     this._formWidth = v ?? "";
@@ -175,6 +190,9 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       this.render();
     } else if (name === "title-align") {
       this._titleAlign = value ?? "left";
+      this.render();
+    } else if (name === "title-color") {
+      this._titleColor = value ?? "";
       this.render();
     } else if (name === "form-width") {
       this._formWidth = value ?? "";
@@ -492,6 +510,9 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       const heading = document.createElement("h2");
       heading.textContent = this._title;
       heading.style.textAlign = this._titleAlign;
+      if (this._titleColor) {
+        heading.style.color = this._titleColor;
+      }
       this._shadow.appendChild(heading);
     }
     this._shadow.appendChild(form);

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -63,6 +63,7 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
       options: ["left", "center", "right"],
       description: "Alignment for the heading text",
     },
+    titleColor: { control: "color", description: "Color for the heading text" },
     formWidth: { control: "text", description: "CSS width applied to the form" },
     layout: { control: "object", description: "Array of column counts per row" },
   },
@@ -108,6 +109,7 @@ export const WithTitle: Story = {
     value: { firstName: "Jane", lastName: "Doe" },
     title: "Registration",
     titleAlign: "center",
+    titleColor: "#ff0000",
   },
   render: (args) => <WavelengthForm {...args} />,
 };


### PR DESCRIPTION
## Summary
- allow WavelengthForm heading color to be customized via `title-color`
- expose `titleColor` prop in React wrapper and typings
- document new prop and add test coverage

## Testing
- `npm run test:jest` *(fails: wavelength-input.test.tsx, web-components/wavelength-form.test.ts, WavelengthInput.test.tsx, Validator.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f10f58c8832596993372d12038a6