### PR TITLE
Default width for wavelength-form component

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -234,6 +234,17 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(input).toHaveAttribute("label", "Override");
   });
 
+  test("defaults formWidth to 300px when prop omitted", async () => {
+    const schema = z.object({ name: z.string() });
+    render(<WavelengthForm schema={schema} />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const form = host.shadowRoot!.querySelector("form") as HTMLFormElement;
+    expect(form.style.width).toBe("300px");
+  });
+
   test("forwards layout and formWidth", async () => {
     const schema = z.object({ a: z.string(), b: z.string(), c: z.string() });
     render(<WavelengthForm schema={schema} layout={[2, 1]} formWidth="350px" />);

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -163,14 +163,21 @@ describe("wavelength-form web component", () => {
     expect(Array.from(rows).every((r) => (r as HTMLElement).children.length === 1)).toBe(true);
   });
 
+  test("renders default form width", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    const form = el.shadowRoot!.querySelector("form") as HTMLFormElement;
+    expect(form.style.width).toBe("300px");
+  });
+
   test("applies formWidth style", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;
-    el.formWidth = "300px";
+    el.formWidth = "400px";
     el.schema = z.object({ a: z.string() });
 
     const form = el.shadowRoot!.querySelector("form") as HTMLFormElement;
-    expect(form.style.width).toBe("300px");
+    expect(form.style.width).toBe("400px");
   });
 
   test("applies title-color style to heading", () => {

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -26,7 +26,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   private _title = "";
   private _titleAlign: string = "left";
   private _titleColor = "";
-  private _formWidth: string = "";
+  private _formWidth: string = "300px";
   private _layout?: number[];
 
   static get observedAttributes() {
@@ -148,7 +148,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
 
   /** Width applied to the form element */
   set formWidth(v: string | undefined) {
-    this._formWidth = v ?? "";
+    this._formWidth = v ?? "300px";
     if (v === undefined) {
       this.removeAttribute("form-width");
     } else {
@@ -156,8 +156,8 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     }
     this.render();
   }
-  get formWidth(): string | undefined {
-    return this._formWidth || undefined;
+  get formWidth(): string {
+    return this._formWidth;
   }
 
   /** Array describing how many fields appear in each row */
@@ -195,7 +195,10 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       this._titleColor = value ?? "";
       this.render();
     } else if (name === "form-width") {
-      this._formWidth = value ?? "";
+      this._formWidth = value ?? "300px";
+      if (value === null) {
+        this.removeAttribute("form-width");
+      }
       this.render();
     }
   }
@@ -348,9 +351,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     const form = document.createElement("form");
     form.noValidate = true;
     form.addEventListener("submit", this.onSubmit);
-    if (this._formWidth) {
-      form.style.width = this._formWidth;
-    }
+    form.style.width = this._formWidth;
 
     // determine layout rows
     const layout: number[] = this._layout && this._layout.length > 0 ? [...this._layout] : [];

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -40,6 +40,9 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
           <p>
             Provide a <code>title</code> to render a heading above the form and control its alignment with <code>titleAlign</code>.
           </p>
+          <p>
+            The form width defaults to <code>300px</code>. Override it with the <code>formWidth</code> prop.
+          </p>
           <h2>Example</h2>
           <Canvas />
           <h2>Props</h2>
@@ -64,7 +67,7 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
       description: "Alignment for the heading text",
     },
     titleColor: { control: "color", description: "Color for the heading text" },
-    formWidth: { control: "text", description: "CSS width applied to the form" },
+    formWidth: { control: "text", description: "CSS width applied to the form (default: 300px)" },
     layout: { control: "object", description: "Array of column counts per row" },
   },
   args: {
@@ -119,6 +122,14 @@ export const WithLayout: Story = {
     schema: sampleSchema,
     value: { firstName: "Jane", lastName: "Doe" },
     layout: [2],
+  },
+  render: (args) => <WavelengthForm {...args} />,
+};
+
+export const CustomFormWidth: Story = {
+  args: {
+    schema: sampleSchema,
+    value: { firstName: "Jane", lastName: "Doe" },
     formWidth: "400px",
   },
   render: (args) => <WavelengthForm {...args} />,


### PR DESCRIPTION
## Summary
- default `<wavelength-form>` to 300px wide and gracefully handle missing `formWidth`
- test web component & React wrapper default width and custom overrides
- document default width and example override in Storybook

## Testing
- `npm test` *(fails: jest/wavelength-input.test.tsx, jest/web-components/wavelength-form.test.ts, jest/WavelengthInput.test.tsx, jest/Validator.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f59382408325a7df7d9eb57460e2