### PR TITLE
feat: prevent form heading selection

### DIFF
--- a/apps/package/jest/WavelengthForm.test.tsx
+++ b/apps/package/jest/WavelengthForm.test.tsx
@@ -198,6 +198,17 @@ describe("WavelengthForm (React Wrapper)", () => {
     expect(heading.style.textAlign).toBe("center");
   });
 
+  test("renders non-selectable title", async () => {
+    const schema = z.object({ name: z.string() });
+    render(<WavelengthForm schema={schema} title="Example" />);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const host = document.querySelector("wavelength-form")!;
+    const heading = host.shadowRoot!.querySelector("h2") as HTMLElement;
+    expect(heading.style.userSelect).toBe("none");
+  });
+
   test("renders title with color", async () => {
     const schema = z.object({ name: z.string() });
     render(<WavelengthForm schema={schema} title="My Form" titleColor="red" />);

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -188,6 +188,14 @@ describe("wavelength-form web component", () => {
     expect(heading.style.color).toBe("blue");
   });
 
+  test("title heading is not selectable", () => {
+    document.body.innerHTML = `<wavelength-form title="Example"></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    const heading = el.shadowRoot!.querySelector("h2") as HTMLElement;
+    expect(heading).not.toBeNull();
+    expect(heading.style.userSelect).toBe("none");
+  });
+
   test("can hide submit button", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -514,6 +514,8 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       if (this._titleColor) {
         heading.style.color = this._titleColor;
       }
+      heading.style.userSelect = "none";
+      heading.style.setProperty("-webkit-user-select", "none");
       this._shadow.appendChild(heading);
     }
     this._shadow.appendChild(form);

--- a/apps/testbed/src/stories/WavelengthForm.stories.tsx
+++ b/apps/testbed/src/stories/WavelengthForm.stories.tsx
@@ -38,7 +38,7 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
             <code>size</code>), and an optional custom event name.
           </p>
           <p>
-            Provide a <code>title</code> to render a heading above the form and control its alignment with <code>titleAlign</code>.
+            Provide a <code>title</code> to render a non-selectable heading above the form and control its alignment with <code>titleAlign</code>.
           </p>
           <p>
             The form width defaults to <code>300px</code>. Override it with the <code>formWidth</code> prop.


### PR DESCRIPTION
## Summary
- prevent text selection on WavelengthForm headings across browsers
- add tests confirming heading user-select behavior
- document non-selectable heading in storybook

## Testing
- `npm run lint` *(fails: Replace `handleChangePage(item),·setIsOpen(false` ...)*
- `npx eslint apps/package/src/web-components/wavelength-form.ts apps/package/jest/web-components/wavelength-form.test.ts apps/package/jest/WavelengthForm.test.tsx apps/testbed/src/stories/WavelengthForm.stories.tsx` *(fails: prettier/prettier errors)*
- `npm run test:jest` *(fails: 4 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fa0a3d548325b4affe5510b5f1da