### PR TITLE
chore: organize react tests into dedicated folder

### DIFF
--- a/apps/package/jest/react/SampleComponent.test.tsx
+++ b/apps/package/jest/react/SampleComponent.test.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { WavelengthTitleBar } from "../src";
+import { SampleComponent } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-describe("WavelengthTitleBar should", () => {
+describe("SampleComponent should", () => {
   it("render", async () => {
     render(
       <div data-testid="default">
-        <WavelengthTitleBar titleText="Test" subtitleText="Test" textColor="hotpink" textShadow />
+        <SampleComponent testProp="Sample Component" children="Sample Component" />
       </div>,
     );
     const titleBar = screen.getByTestId("default");

--- a/apps/package/jest/react/StyledButton.test.tsx
+++ b/apps/package/jest/react/StyledButton.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { expect } from "@jest/globals";
-import { WavelengthStyledButton } from "../src";
+import { WavelengthStyledButton } from "../../src";
 
 describe("WavelengthStyledButton", () => {
   it("renders with default type", () => {

--- a/apps/package/jest/react/WLAutocomplete.test.tsx
+++ b/apps/package/jest/react/WLAutocomplete.test.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useRef, useState, KeyboardEvent, act } from "react";
-import { WLAutoComplete } from "../src";
+import { WLAutoComplete } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/apps/package/jest/react/WLDatePicker.test.tsx
+++ b/apps/package/jest/react/WLDatePicker.test.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useEffect, useRef, useState, KeyboardEvent, act } from "react";
-import { WLDatePicker } from "../src";
+import { WLDatePicker } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/apps/package/jest/react/WavelengthAppLogo.test.tsx
+++ b/apps/package/jest/react/WavelengthAppLogo.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthAppLogo } from "../src";
+import { WavelengthAppLogo } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 

--- a/apps/package/jest/react/WavelengthBox.test.tsx
+++ b/apps/package/jest/react/WavelengthBox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthBox } from "../src";
+import { WavelengthBox } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 

--- a/apps/package/jest/react/WavelengthButton.test.tsx
+++ b/apps/package/jest/react/WavelengthButton.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { WavelengthButton } from "../src";
+import { WavelengthButton } from "../../src";
 import { jest } from "@jest/globals";
 import "@testing-library/jest-dom";
 

--- a/apps/package/jest/react/WavelengthCommentDisplay.test.tsx
+++ b/apps/package/jest/react/WavelengthCommentDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { WavelengthCommentDisplay } from "../src";
+import { WavelengthCommentDisplay } from "../../src";
 
 import { expect } from "@jest/globals";
 

--- a/apps/package/jest/react/WavelengthContentPlaceholder.test.tsx
+++ b/apps/package/jest/react/WavelengthContentPlaceholder.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthContentPlaceholder } from "../src";
+import { WavelengthContentPlaceholder } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 

--- a/apps/package/jest/react/WavelengthDataTable.test.tsx
+++ b/apps/package/jest/react/WavelengthDataTable.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthDataTable } from "../src";
+import { WavelengthDataTable } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/apps/package/jest/react/WavelengthDefaultIcon.test.tsx
+++ b/apps/package/jest/react/WavelengthDefaultIcon.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthDefaultIcon, WavelengthFooter } from "../src";
+import { WavelengthDefaultIcon, WavelengthFooter } from "../../src";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 describe("Default Icon", () => {

--- a/apps/package/jest/react/WavelengthFooter.test.tsx
+++ b/apps/package/jest/react/WavelengthFooter.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthFooter } from "../src";
+import { WavelengthFooter } from "../../src";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 describe("Wavelength Footer", () => {

--- a/apps/package/jest/react/WavelengthForm.test.tsx
+++ b/apps/package/jest/react/WavelengthForm.test.tsx
@@ -3,10 +3,10 @@ import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { z } from "zod";
 
-import WavelengthForm from "../src/components/forms/WavelengthForm";
-import "../src/web-components/wavelength-form";
-import "../src/web-components/wavelength-input";
-import "../src/web-components/wavelength-button";
+import WavelengthForm from "../../src/components/forms/WavelengthForm";
+import "../../src/web-components/wavelength-form";
+import "../../src/web-components/wavelength-input";
+import "../../src/web-components/wavelength-button";
 
 // This test focuses on the React wrapper receiving the correct
 // detail payloads from the custom events.

--- a/apps/package/jest/react/WavelengthInput.test.tsx
+++ b/apps/package/jest/react/WavelengthInput.test.tsx
@@ -1,9 +1,9 @@
 import React, { useRef } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { WavelengthInput } from "../src/components/TextField/WavelengthInput";
+import { WavelengthInput } from "../../src/components/TextField/WavelengthInput";
 
-import "../src/web-components/wavelength-input";
+import "../../src/web-components/wavelength-input";
 
 describe("WavelengthInput (React Wrapper)", () => {
   test("renders and sets props as attributes", () => {

--- a/apps/package/jest/react/WavelengthManyPlanes.test.tsx
+++ b/apps/package/jest/react/WavelengthManyPlanes.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { jest } from "@jest/globals";
 import { render, waitFor, screen, fireEvent } from "@testing-library/react";
-import { WavelengthManyPlanes } from "../src";
+import { WavelengthManyPlanes } from "../../src";
 
 function getManyPlanes() {
   return (

--- a/apps/package/jest/react/WavelengthNotAvailablePage.test.tsx
+++ b/apps/package/jest/react/WavelengthNotAvailablePage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthNotAvailablePage } from "../src";
+import { WavelengthNotAvailablePage } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 

--- a/apps/package/jest/react/WavelengthPlaneTrail.test.tsx
+++ b/apps/package/jest/react/WavelengthPlaneTrail.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WavelengthPlaneTrail } from "../src";
+import { WavelengthPlaneTrail } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 

--- a/apps/package/jest/react/WavelengthTitleBar.test.tsx
+++ b/apps/package/jest/react/WavelengthTitleBar.test.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { SampleComponent } from "../src";
+import { WavelengthTitleBar } from "../../src";
 import { expect } from "@jest/globals";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-describe("SampleComponent should", () => {
+describe("WavelengthTitleBar should", () => {
   it("render", async () => {
     render(
       <div data-testid="default">
-        <SampleComponent testProp="Sample Component" children="Sample Component" />
+        <WavelengthTitleBar titleText="Test" subtitleText="Test" textColor="hotpink" textShadow />
       </div>,
     );
     const titleBar = screen.getByTestId("default");


### PR DESCRIPTION
## Summary
- add `apps/package/jest/react` to house React-focused unit tests
- update moved tests to use new relative imports

## Testing
- `npm test` *(fails: wavelength-input, wavelength-form, WavelengthInput, Validator)*

------
https://chatgpt.com/codex/tasks/task_e_68c326bcac2c8325876751caed9bba65