### PR TITLE
test: ensure helper color changes on forced error

### DIFF
--- a/apps/package/jest/web-components/wavelength-input.test.ts
+++ b/apps/package/jest/web-components/wavelength-input.test.ts
@@ -212,10 +212,11 @@ describe("<wavelength-input>", () => {
     const helper = element.shadowRoot!.getElementById("helper") as HTMLElement;
     expect(helper.style.color).toBe("rgb(0, 255, 0)");
 
+    element.setAttribute("error-message", "Forced error");
     element.setAttribute("force-error", "");
     (element as any).validate(true);
 
-    expect(helper.style.color).not.toBe("rgb(0, 255, 0)");
+    expect(helper.style.color).toBe("red");
   });
 
   test("upgrades property when already set before connection", () => {


### PR DESCRIPTION
## Summary
- ensure helper message color is set to red when forced error is applied

## Testing
- `npm run test:jest` *(fails: wavelength-form web component > renders multiple error messages; WavelengthInput React wrapper > defaults to required message when forceError without errorMessage; WavelengthInput React wrapper > uses provided errorMessage when present with forceError; Validator test suite failed to run: Cannot find module '../src/form/Validator')*

------
https://chatgpt.com/codex/tasks/task_e_68c4230ec6cc8325a6589cf3c5173c00