### PR TITLE
Set WavelengthForm display name

### DIFF
--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -236,7 +236,10 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
   return <wavelength-form ref={hostRef as any} className={className} style={style} />;
 }
 
-export const WavelengthForm = React.forwardRef(WavelengthFormInner) as <T extends object = Record<string, unknown>>(
+const WavelengthFormForwardRef = React.forwardRef(WavelengthFormInner);
+WavelengthFormForwardRef.displayName = "WavelengthForm";
+
+export const WavelengthForm = WavelengthFormForwardRef as <T extends object = Record<string, unknown>>(
   props: WavelengthFormProps<T> & React.RefAttributes<WavelengthFormRef<T>>,
 ) => React.ReactElement | null;
 


### PR DESCRIPTION
## Summary
- add a displayName to the WavelengthForm forwardRef wrapper so Storybook labels the component correctly

## Testing
- npm run build:package
- CI=1 npm run build-storybook

------
https://chatgpt.com/codex/tasks/task_e_68c85861fea083258bf7d4d98779fe1c