### PR TITLE
Add displayName to package React components

### DIFF
--- a/apps/package/src/components/AutoComplete/WlAutoComplete.tsx
+++ b/apps/package/src/components/AutoComplete/WlAutoComplete.tsx
@@ -320,4 +320,6 @@ export const WLAutoComplete = ({
   );
 };
 
+WLAutoComplete.displayName = "WLAutoComplete";
+
 export default WLAutoComplete;

--- a/apps/package/src/components/CSFD/GreenEllipse.tsx
+++ b/apps/package/src/components/CSFD/GreenEllipse.tsx
@@ -39,4 +39,6 @@ export function GreenEllipse({ width = 65, height = 65, initials = "HW" }: Ellip
   );
 }
 
+GreenEllipse.displayName = "GreenEllipse";
+
 export default GreenEllipse;

--- a/apps/package/src/components/CSFD/WavelengthManyPlanes.tsx
+++ b/apps/package/src/components/CSFD/WavelengthManyPlanes.tsx
@@ -69,4 +69,6 @@ export function WavelengthManyPlanes({ numberOfPlanes = 5, trailDir = "left", co
   return PlaneGridWrapper(numberOfPlanes, opacity);
 }
 
+WavelengthManyPlanes.displayName = "WavelengthManyPlanes";
+
 export default WavelengthManyPlanes;

--- a/apps/package/src/components/DataTable/NestedDataTable/NestedDataTable.tsx
+++ b/apps/package/src/components/DataTable/NestedDataTable/NestedDataTable.tsx
@@ -216,4 +216,6 @@ export const NestedDataTable = <T extends DataType>({ data, columns }: Props<T>)
   );
 };
 
+NestedDataTable.displayName = "NestedDataTable";
+
 export default NestedDataTable;

--- a/apps/package/src/components/DataTable/SubRowTable/ChildSubTable.tsx
+++ b/apps/package/src/components/DataTable/SubRowTable/ChildSubTable.tsx
@@ -459,4 +459,6 @@ export const ChildDataTable = <T extends DataType>({ data, columns, downloadArro
   );
 };
 
+ChildDataTable.displayName = "ChildDataTable";
+
 export default ChildDataTable;

--- a/apps/package/src/components/DataTable/WavelengthDataTable.tsx
+++ b/apps/package/src/components/DataTable/WavelengthDataTable.tsx
@@ -478,4 +478,6 @@ export const WavelengthDataTable = <T extends DataType>({ data, columns, itemsPe
   );
 };
 
+WavelengthDataTable.displayName = "WavelengthDataTable";
+
 export default WavelengthDataTable;

--- a/apps/package/src/components/PageComponents/WavelengthAccessAlert.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthAccessAlert.tsx
@@ -144,4 +144,6 @@ export function WavelengthAccessAlert({
   }
 }
 
+WavelengthAccessAlert.displayName = "WavelengthAccessAlert";
+
 export default WavelengthAccessAlert;

--- a/apps/package/src/components/PageComponents/WavelengthAlert.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthAlert.tsx
@@ -151,4 +151,6 @@ export function WavelengthAlert({
     );
   }
 }
+
+WavelengthAlert.displayName = "WavelengthAlert";
 export default WavelengthAlert;

--- a/apps/package/src/components/PageComponents/WavelengthCommentDisplay.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthCommentDisplay.tsx
@@ -64,4 +64,6 @@ export function WavelengthCommentDisplay(props: CommentProps) {
   );
 }
 
+WavelengthCommentDisplay.displayName = "WavelengthCommentDisplay";
+
 export default WavelengthCommentDisplay;

--- a/apps/package/src/components/PageComponents/WavelengthDragAndDrop.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthDragAndDrop.tsx
@@ -91,4 +91,6 @@ export function WavelengthDragAndDrop({
   );
 }
 
+WavelengthDragAndDrop.displayName = "WavelengthDragAndDrop";
+
 export default WavelengthDragAndDrop;

--- a/apps/package/src/components/PageComponents/WavelengthNotAvailablePage.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthNotAvailablePage.tsx
@@ -35,4 +35,6 @@ export function WavelengthNotAvailablePage({ WavelengthAppLogoName, errorMessage
   );
 }
 
+WavelengthNotAvailablePage.displayName = "WavelengthNotAvailablePage";
+
 export default WavelengthNotAvailablePage;

--- a/apps/package/src/components/PageComponents/WavelengthPermissionAlert.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthPermissionAlert.tsx
@@ -68,4 +68,6 @@ export function WavelengthPermissionAlert({
   );
 }
 
+WavelengthPermissionAlert.displayName = "WavelengthPermissionAlert";
+
 export default WavelengthPermissionAlert;

--- a/apps/package/src/components/PageComponents/WavelengthProgressBar.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthProgressBar.tsx
@@ -31,4 +31,6 @@ export const WavelengthProgressBar: React.FC<WavelengthProgressBarProps> = ({ na
   return <wavelength-progress-bar ref={ref} {...rest} />;
 };
 
+WavelengthProgressBar.displayName = "WavelengthProgressBar";
+
 export default WavelengthProgressBar;

--- a/apps/package/src/components/PageComponents/WavelengthSideBar.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthSideBar.tsx
@@ -131,4 +131,6 @@ export function WavelengthSideBar({ sections, txtColor, bgColor, labelColor, arr
   );
 }
 
+WavelengthSideBar.displayName = "WavelengthSideBar";
+
 export default WavelengthSideBar;

--- a/apps/package/src/components/PageComponents/WavelengthSpinningLogo.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthSpinningLogo.tsx
@@ -68,4 +68,6 @@ export function WavelengthSpinningOuterCircle({ size, id, clip, color, gradient,
   );
 }
 
+WavelengthSpinningOuterCircle.displayName = "WavelengthSpinningOuterCircle";
+
 export default WavelengthSpinningOuterCircle;

--- a/apps/package/src/components/PageComponents/WavelengthSpinningLogoComponent.tsx
+++ b/apps/package/src/components/PageComponents/WavelengthSpinningLogoComponent.tsx
@@ -75,4 +75,6 @@ export function WavelengthSpinningLogo({ svg = <span>SVG Goes Here</span>, size 
   return loadingSymbol;
 }
 
+WavelengthSpinningLogo.displayName = "WavelengthSpinningLogo";
+
 export default WavelengthSpinningLogo;

--- a/apps/package/src/components/buttons/WavelengthButton/WavelengthButton.tsx
+++ b/apps/package/src/components/buttons/WavelengthButton/WavelengthButton.tsx
@@ -112,4 +112,6 @@ export const WavelengthButton: React.FC<WavelengthButtonProps> = ({
   );
 };
 
+WavelengthButton.displayName = "WavelengthButton";
+
 export default WavelengthButton;

--- a/apps/package/src/components/buttons/WavelengthButton/WavelengthStyledButton.tsx
+++ b/apps/package/src/components/buttons/WavelengthButton/WavelengthStyledButton.tsx
@@ -454,4 +454,6 @@ export function WavelengthStyledButton({ type = "default", styles, children, dis
   );
 }
 
+WavelengthStyledButton.displayName = "WavelengthStyledButton";
+
 export default WavelengthStyledButton;

--- a/apps/package/src/components/buttons/WavelengthDropdownButton/WavelengthAutocomplete.tsx
+++ b/apps/package/src/components/buttons/WavelengthDropdownButton/WavelengthAutocomplete.tsx
@@ -103,4 +103,6 @@ export function WavelengthAutocomplete({ label, width = 300, variant = "outlined
   );
 }
 
+WavelengthAutocomplete.displayName = "WavelengthAutocomplete";
+
 export default WavelengthAutocomplete;

--- a/apps/package/src/components/buttons/WavelengthDropdownButton/WavelengthDropdownButton.tsx
+++ b/apps/package/src/components/buttons/WavelengthDropdownButton/WavelengthDropdownButton.tsx
@@ -61,6 +61,8 @@ export function ButtonIcon({ text, numIcon = "0", children, active = false, widt
   );
 }
 
+ButtonIcon.displayName = "ButtonIcon";
+
 function renderButtonIcon(children: ReactNode) {
   for (const c of React.Children.toArray(children)) {
     const obj = c as { type: { name: string } };
@@ -77,6 +79,8 @@ interface ButtonMenuProps {
 export function ButtonMenu({ children }: ButtonMenuProps) {
   return <div style={{ background: "transparent" }}>{children}</div>;
 }
+
+ButtonMenu.displayName = "ButtonMenu";
 
 function renderButtonMenu(children: ReactNode) {
   for (const c of React.Children.toArray(children)) {
@@ -108,5 +112,7 @@ export function WavelengthDropdownButton({ children, onClick }: ButtonProps): Re
     </>
   );
 }
+
+WavelengthDropdownButton.displayName = "WavelengthDropdownButton";
 
 export default WavelengthDropdownButton;

--- a/apps/package/src/components/buttons/WavelengthFileDownloader.tsx
+++ b/apps/package/src/components/buttons/WavelengthFileDownloader.tsx
@@ -39,4 +39,6 @@ export function WavelengthFileDownloader({ fileLoc, fileURL, fileName, button, i
   }
 }
 
+WavelengthFileDownloader.displayName = "WavelengthFileDownloader";
+
 export default WavelengthFileDownloader;

--- a/apps/package/src/components/carousels/WavelengthDefaultCarousel.tsx
+++ b/apps/package/src/components/carousels/WavelengthDefaultCarousel.tsx
@@ -92,4 +92,6 @@ export const DefaultCarousel: React.FC<carouselConfigArray & adjustableDimension
   );
 };
 
+DefaultCarousel.displayName = "DefaultCarousel";
+
 export default DefaultCarousel;

--- a/apps/package/src/components/carousels/WavelengthSliderCarousel.tsx
+++ b/apps/package/src/components/carousels/WavelengthSliderCarousel.tsx
@@ -118,4 +118,6 @@ export const SliderCardCarousel: React.FC<carouselConfigArray & adjustDimenforCa
   );
 };
 
+SliderCardCarousel.displayName = "SliderCardCarousel";
+
 export default SliderCardCarousel;

--- a/apps/package/src/components/containers/WavelengthBox/WavelengthBox.tsx
+++ b/apps/package/src/components/containers/WavelengthBox/WavelengthBox.tsx
@@ -40,4 +40,6 @@ export function WavelengthBox({ width, height, children, borderBottomRadius, bor
   );
 }
 
+WavelengthBox.displayName = "WavelengthBox";
+
 export default WavelengthBox;

--- a/apps/package/src/components/containers/WavelengthContentPlaceholder/WavelengthContentPlaceholder.tsx
+++ b/apps/package/src/components/containers/WavelengthContentPlaceholder/WavelengthContentPlaceholder.tsx
@@ -59,4 +59,6 @@ export function WavelengthContentPlaceholder({ type, width, height, txtcolor, bg
   //#endregion
 }
 
+WavelengthContentPlaceholder.displayName = "WavelengthContentPlaceholder";
+
 export default WavelengthContentPlaceholder;

--- a/apps/package/src/components/example/WavelengthExampleComponent.tsx
+++ b/apps/package/src/components/example/WavelengthExampleComponent.tsx
@@ -38,4 +38,6 @@ export function WavelengthExampleComponent({ width = 100, height = 100 }: Wavele
   );
 }
 
+WavelengthExampleComponent.displayName = "WavelengthExampleComponent";
+
 export default WavelengthExampleComponent;

--- a/apps/package/src/components/footers/WavelengthFooter/WavelengthFooter.tsx
+++ b/apps/package/src/components/footers/WavelengthFooter/WavelengthFooter.tsx
@@ -66,3 +66,4 @@ export function WavelengthFooter({ text, textColor }: WavelengthFooterProps) {
     </Box>
   );
 }
+WavelengthFooter.displayName = "WavelengthFooter";

--- a/apps/package/src/components/headers/WavelengthTitleBar/WavelengthBanner.tsx
+++ b/apps/package/src/components/headers/WavelengthTitleBar/WavelengthBanner.tsx
@@ -33,4 +33,6 @@ export function WavelengthBanner({ bannerText, bannerColor, textColor, opacity =
   return <wavelength-banner ref={ref} />;
 }
 
+WavelengthBanner.displayName = "WavelengthBanner";
+
 export default WavelengthBanner;

--- a/apps/package/src/components/headers/WavelengthTitleBar/WavelengthTitleBar.tsx
+++ b/apps/package/src/components/headers/WavelengthTitleBar/WavelengthTitleBar.tsx
@@ -23,4 +23,6 @@ export function WavelengthTitleBar({ titleText, subtitleText, textColor, textSha
   return <wavelength-title-bar ref={ref}></wavelength-title-bar>;
 }
 
+WavelengthTitleBar.displayName = "WavelengthTitleBar";
+
 export default WavelengthTitleBar;

--- a/apps/package/src/components/inputs/WLDatePicker.tsx
+++ b/apps/package/src/components/inputs/WLDatePicker.tsx
@@ -156,4 +156,6 @@ export const WLDatePicker = ({ labelVariant, labelColor, borderColor, FocusBorde
   );
 };
 
+WLDatePicker.displayName = "WLDatePicker";
+
 export default WLDatePicker;

--- a/apps/package/src/components/inputs/WavelengthInputDatePicketer.tsx
+++ b/apps/package/src/components/inputs/WavelengthInputDatePicketer.tsx
@@ -13,6 +13,7 @@ export const WLInputDatePicker: React.FC = () => {
 
   return <wavelength-input-date-picker ref={ref} />;
 };
+WLInputDatePicker.displayName = "WLInputDatePicker";
 //WLInputDatePicker
 export default WLInputDatePicker;
 

--- a/apps/package/src/components/logos/applogo/WavelengthAppLogo.tsx
+++ b/apps/package/src/components/logos/applogo/WavelengthAppLogo.tsx
@@ -380,6 +380,7 @@ export function WavelengthAppLogo({ width, height, name = "", grayscale, id }: W
   }
   return <div>{logo}</div>;
 }
+WavelengthAppLogo.displayName = "WavelengthAppLogo";
 /* eslint-ignore */
 
 export default WavelengthAppLogo;

--- a/apps/package/src/components/logos/default/WavelengthDefaultIcon.tsx
+++ b/apps/package/src/components/logos/default/WavelengthDefaultIcon.tsx
@@ -38,4 +38,6 @@ export function WavelengthDefaultIcon({ width = "180", height = 140 }: DefaultPr
   );
 }
 
+WavelengthDefaultIcon.displayName = "WavelengthDefaultIcon";
+
 export default WavelengthDefaultIcon;

--- a/apps/package/src/components/modals/WavelengthConfirmationModal.tsx
+++ b/apps/package/src/components/modals/WavelengthConfirmationModal.tsx
@@ -53,4 +53,6 @@ export function WavelengthConfirmationModal(props: WavelengthConfirmationModalPr
   );
 }
 
+WavelengthConfirmationModal.displayName = "WavelengthConfirmationModal";
+
 export default WavelengthConfirmationModal;

--- a/apps/package/src/components/modals/WavelengthContentModal.tsx
+++ b/apps/package/src/components/modals/WavelengthContentModal.tsx
@@ -37,4 +37,6 @@ export function WavelengthContentModal(props: WavelengthContentModalProps) {
   );
 }
 
+WavelengthContentModal.displayName = "WavelengthContentModal";
+
 export default WavelengthContentModal;

--- a/apps/package/src/components/modals/WavelengthDropdown.tsx
+++ b/apps/package/src/components/modals/WavelengthDropdown.tsx
@@ -160,5 +160,8 @@ export function WavelengthDropdown({
   );
 }
 
+WavelengthDropdown.displayName = "WavelengthDropdown";
+
 const WavelengthDropdownStyled = styled(WavelengthDropdown)``;
+WavelengthDropdownStyled.displayName = "WavelengthDropdownStyled";
 export default WavelengthDropdownStyled;

--- a/apps/package/src/components/modals/WavelengthPopUpMenu.tsx
+++ b/apps/package/src/components/modals/WavelengthPopUpMenu.tsx
@@ -219,4 +219,6 @@ export function WavelengthPopUpMenu({ menuItems, customIcon = false, width, menu
   );
 }
 
+WavelengthPopUpMenu.displayName = "WavelengthPopUpMenu";
+
 export default WavelengthPopUpMenu;

--- a/apps/package/src/components/pagination/WavelengthButtonPagination.tsx
+++ b/apps/package/src/components/pagination/WavelengthButtonPagination.tsx
@@ -153,4 +153,6 @@ export function WavelengthButtonPagination({ totalPages, current, handleChangePa
   );
 }
 
+WavelengthButtonPagination.displayName = "WavelengthButtonPagination";
+
 export default WavelengthButtonPagination;

--- a/apps/package/src/components/pagination/WavelengthDefaultPagination.tsx
+++ b/apps/package/src/components/pagination/WavelengthDefaultPagination.tsx
@@ -115,4 +115,6 @@ export function DefaultPagination({ totalPages, currentPageNumber, siblingCount 
   }
 }
 
+DefaultPagination.displayName = "DefaultPagination";
+
 export default DefaultPagination;

--- a/apps/package/src/components/pagination/WavelengthVariationPagination.tsx
+++ b/apps/package/src/components/pagination/WavelengthVariationPagination.tsx
@@ -135,4 +135,6 @@ export function WavelengthVariationPagination({ totalPages, current, variant, ha
   );
 }
 
+WavelengthVariationPagination.displayName = "WavelengthVariationPagination";
+
 export default WavelengthVariationPagination;

--- a/apps/package/src/components/samples/SampleComponent.tsx
+++ b/apps/package/src/components/samples/SampleComponent.tsx
@@ -34,4 +34,6 @@ export const SampleComponent: React.FC<SampleComponentProps> = ({
   );
 };
 
+SampleComponent.displayName = "SampleComponent";
+
 export default SampleComponent;

--- a/apps/package/src/components/search/WavelengthSearch.tsx
+++ b/apps/package/src/components/search/WavelengthSearch.tsx
@@ -631,4 +631,6 @@ export function WavelengthSearch({
   return undefined;
 }
 
+WavelengthSearch.displayName = "WavelengthSearch";
+
 export default WavelengthSearch;

--- a/apps/package/src/components/search/WavelengthSearchTextField.tsx
+++ b/apps/package/src/components/search/WavelengthSearchTextField.tsx
@@ -26,4 +26,6 @@ export function WavelengthSearchTextField() {
   return <WavelengthSearchTextField />;
 }
 
+WavelengthSearchTextField.displayName = "WavelengthSearchTextField";
+
 export default WavelengthSearchTextField;

--- a/apps/package/src/components/separators/WavelengthPlaneTrail/WavelengthPlaneTrail.tsx
+++ b/apps/package/src/components/separators/WavelengthPlaneTrail/WavelengthPlaneTrail.tsx
@@ -53,4 +53,6 @@ export function WavelengthPlaneTrail({ trailDir = "right", id, color }: Waveleng
   );
 }
 
+WavelengthPlaneTrail.displayName = "WavelengthPlaneTrail";
+
 export default WavelengthPlaneTrail;

--- a/apps/package/src/components/sliders/WavelengthSlider.tsx
+++ b/apps/package/src/components/sliders/WavelengthSlider.tsx
@@ -44,4 +44,6 @@ export function WavelengthSlider({ width = "300px", color, valueDisplayed, marks
   );
 }
 
+WavelengthSlider.displayName = "WavelengthSlider";
+
 export default WavelengthSlider;

--- a/apps/package/src/components/snackbars/WavelengthSnackbar.tsx
+++ b/apps/package/src/components/snackbars/WavelengthSnackbar.tsx
@@ -70,4 +70,6 @@ export function WavelengthSnackbar({ show, setShow, closeIcon, message, snackBar
   );
 }
 
+WavelengthSnackbar.displayName = "WavelengthSnackbar";
+
 export default WavelengthSnackbar;

--- a/apps/package/src/components/snackbars/WavelengthStandardSnackbar.tsx
+++ b/apps/package/src/components/snackbars/WavelengthStandardSnackbar.tsx
@@ -82,4 +82,6 @@ export function WavelengthStandardSnackbar({ type, show, icon, horryAlign, verty
     </Snackbar>
   );
 }
+
+WavelengthStandardSnackbar.displayName = "WavelengthStandardSnackbar";
 export default WavelengthStandardSnackbar;

--- a/apps/package/src/components/snackbars/WavelengthTestSnackbar.tsx
+++ b/apps/package/src/components/snackbars/WavelengthTestSnackbar.tsx
@@ -84,3 +84,5 @@ export function WavelengthTestSnackbar({ isPopUpOpen, toggleOpen, type, message,
     </>
   );
 }
+
+WavelengthTestSnackbar.displayName = "WavelengthTestSnackbar";


### PR DESCRIPTION
## Summary
- add explicit `displayName` assignments across the package's exported React components so they show meaningful names in React DevTools

## Testing
- `npm run build:package`
- `CI=1 npm run build-storybook` *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c86114f860832588f4792cb4c65a8b