### PR TITLE
Update WavelengthForm submit events and docs

### DIFF
--- a/apps/package/README.md
+++ b/apps/package/README.md
@@ -18,7 +18,7 @@ npm install @wavelengthusaf/components
 `centerButton`, and/or `rightButton` object with a `label`, optional
 `buttonProps` forwarded as attributes to the underlying `<wavelength-button>`,
 and an optional `eventName` to customize the emitted event. Default events are
-`form-back`, `form-center`, and `form-submit`.
+`form-left`, `form-center`, and `form-right`.
 
 ```tsx
 <WavelengthForm
@@ -33,17 +33,20 @@ and an optional `eventName` to customize the emitted event. Default events are
   }}
   rightButton={{
     label: "Next",
-    buttonProps: { id: "next-btn", variant: "contained", size: "large" },
+    buttonProps: { id: "next-btn", type: "submit", variant: "contained", size: "large" },
   }}
-  onBack={() => console.log("back")}
+  onLeft={() => console.log("left")}
   onCenter={() => console.log("center")}
-  onSubmit={() => console.log("submit")}
+  onRight={() => console.log("right")}
+  onSubmit={(event) => console.log("submit", event)}
 />
 ```
 
 The `buttonProps` object is forwarded as attributes to
 `<wavelength-button>`, allowing you to customize each button via properties
-like `variant` or `size`.
+like `variant` or `size`. Any action button can submit the form by setting
+`buttonProps.type = 'submit'`; pair it with the `onSubmit` callback to tap into
+the native `SubmitEvent` when you need to work with the posted form data.
 
 ## Release Notes
 

--- a/apps/package/jest/react/WavelengthForm.test.tsx
+++ b/apps/package/jest/react/WavelengthForm.test.tsx
@@ -272,18 +272,20 @@ describe("WavelengthForm (React Wrapper)", () => {
 
   test("default button events trigger callbacks", async () => {
     const schema = z.object({ name: z.string() });
-    const onBack = jest.fn();
+    const onLeft = jest.fn();
     const onCenter = jest.fn();
+    const onRight = jest.fn();
     const onSubmit = jest.fn();
     render(
       <WavelengthForm
         schema={schema}
-        onBack={onBack}
+        onLeft={onLeft}
         onCenter={onCenter}
+        onRight={onRight}
         onSubmit={onSubmit}
         leftButton={{ label: "Back" }}
         centerButton={{ label: "Center" }}
-        rightButton={{ label: "Next" }}
+        rightButton={{ label: "Next", buttonProps: { type: "submit" } }}
       />,
     );
 
@@ -296,9 +298,14 @@ describe("WavelengthForm (React Wrapper)", () => {
     back.click();
     center.click();
     submit.click();
+    await new Promise((r) => setTimeout(r, 0));
 
-    expect(onBack).toHaveBeenCalled();
+    expect(onLeft).toHaveBeenCalled();
     expect(onCenter).toHaveBeenCalled();
+    expect(onRight).toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalled();
+    const submitEvent = onSubmit.mock.calls[0]?.[0];
+    expect(submitEvent).toBeInstanceOf(Event);
+    expect(submitEvent?.type).toBe("submit");
   });
 });

--- a/apps/package/jest/web-components/wavelength-form.test.ts
+++ b/apps/package/jest/web-components/wavelength-form.test.ts
@@ -35,7 +35,7 @@ describe("wavelength-form web component", () => {
     el.addEventListener("form-change", (e: Event) => change((e as CustomEvent).detail));
     el.addEventListener("form-valid", (e: Event) => valid((e as CustomEvent).detail));
 
-    el.rightButton = { label: "Submit" };
+    el.rightButton = { label: "Submit", buttonProps: { type: "submit" } };
 
     const input = el.shadowRoot!.querySelector("wavelength-input") as any;
     input.value = "A";
@@ -55,7 +55,7 @@ describe("wavelength-form web component", () => {
     const invalid = jest.fn();
     el.addEventListener("form-invalid", (e: Event) => invalid((e as CustomEvent).detail));
 
-    el.rightButton = { label: "Submit" };
+    el.rightButton = { label: "Submit", buttonProps: { type: "submit" } };
     const button = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(button);
     expect(invalid).toHaveBeenCalled();
@@ -73,7 +73,7 @@ describe("wavelength-form web component", () => {
       password: z.string().min(5, { message: "Too short" }).regex(/[A-Z]/, { message: "Must include capital" }),
     });
 
-    el.rightButton = { label: "Submit" };
+    el.rightButton = { label: "Submit", buttonProps: { type: "submit" } };
     const button = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(button);
 
@@ -204,16 +204,37 @@ describe("wavelength-form web component", () => {
     expect(button).toBeNull();
   });
 
-  test("emits form-back when back button clicked", () => {
+  test("emits form-left when left button clicked", () => {
     document.body.innerHTML = `<wavelength-form></wavelength-form>`;
     const el = document.querySelector("wavelength-form") as any;
     el.leftButton = { label: "Back" };
     el.schema = z.object({ name: z.string() });
 
     const handler = jest.fn();
-    el.addEventListener("form-back", handler);
+    el.addEventListener("form-left", handler);
     const back = el.shadowRoot!.querySelector("wavelength-button")!;
     fireEvent.click(back);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  test("requests submit when submit-type button clicked", () => {
+    document.body.innerHTML = `<wavelength-form></wavelength-form>`;
+    const el = document.querySelector("wavelength-form") as any;
+    el.rightButton = { label: "Submit", buttonProps: { type: "submit" } };
+    el.schema = z.object({ name: z.string() });
+
+    const handler = jest.fn();
+    el.addEventListener("form-right", handler);
+
+    const form = el.shadowRoot!.querySelector("form") as HTMLFormElement & {
+      requestSubmit: jest.Mock;
+    };
+    form.requestSubmit = jest.fn();
+
+    const button = el.shadowRoot!.querySelector("wavelength-button:last-of-type")!;
+    fireEvent.click(button);
+
+    expect(form.requestSubmit).toHaveBeenCalled();
     expect(handler).toHaveBeenCalled();
   });
 });

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -77,12 +77,14 @@ export interface WavelengthFormProps<T extends object = Record<string, unknown>>
   onChange?: (value: Partial<T>, issues: z.ZodIssue[]) => void;
   onValid?: (value: T, issues: z.ZodIssue[]) => void;
   onInvalid?: (value: Partial<T>, issues: z.ZodIssue[]) => void;
-  /** Fired when the default back event is triggered */
-  onBack?: () => void;
+  /** Fired when the default left event is triggered */
+  onLeft?: () => void;
   /** Fired when the default center event is triggered */
   onCenter?: () => void;
-  /** Fired when the default submit event is triggered */
-  onSubmit?: () => void;
+  /** Fired when the default right event is triggered */
+  onRight?: () => void;
+  /** Fired when the underlying form emits a native submit event */
+  onSubmit?: (event: SubmitEvent) => void;
 }
 
 export interface WavelengthFormRef<T extends object = Record<string, unknown>> {
@@ -122,8 +124,9 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     placeholders,
     formWidth,
     layout,
-    onBack,
+    onLeft,
     onCenter,
+    onRight,
     onSubmit,
   } = props;
   const hostRef = useRef<WavelengthFormElement | null>(null);
@@ -131,8 +134,9 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
   const onChangeStable = useStableCallback(onChange);
   const onValidStable = useStableCallback(onValid);
   const onInvalidStable = useStableCallback(onInvalid);
-  const onBackStable = useStableCallback(onBack);
+  const onLeftStable = useStableCallback(onLeft);
   const onCenterStable = useStableCallback(onCenter);
+  const onRightStable = useStableCallback(onRight);
   const onSubmitStable = useStableCallback(onSubmit);
 
   // Set properties & bind events
@@ -206,19 +210,29 @@ function WavelengthFormInner<T extends object = Record<string, unknown>>(props: 
     el.addEventListener("form-change", handleChange as EventListener);
     el.addEventListener("form-valid", handleValid as EventListener);
     el.addEventListener("form-invalid", handleInvalid as EventListener);
-    el.addEventListener("form-back", onBackStable as EventListener);
+    el.addEventListener("form-left", onLeftStable as EventListener);
     el.addEventListener("form-center", onCenterStable as EventListener);
-    el.addEventListener("form-submit", onSubmitStable as EventListener);
+    el.addEventListener("form-right", onRightStable as EventListener);
+    el.addEventListener("submit", onSubmitStable as EventListener);
 
     return () => {
       el.removeEventListener("form-change", handleChange as EventListener);
       el.removeEventListener("form-valid", handleValid as EventListener);
       el.removeEventListener("form-invalid", handleInvalid as EventListener);
-      el.removeEventListener("form-back", onBackStable as EventListener);
+      el.removeEventListener("form-left", onLeftStable as EventListener);
       el.removeEventListener("form-center", onCenterStable as EventListener);
-      el.removeEventListener("form-submit", onSubmitStable as EventListener);
+      el.removeEventListener("form-right", onRightStable as EventListener);
+      el.removeEventListener("submit", onSubmitStable as EventListener);
     };
-  }, [onChangeStable, onValidStable, onInvalidStable, onBackStable, onCenterStable, onSubmitStable]);
+  }, [
+    onChangeStable,
+    onValidStable,
+    onInvalidStable,
+    onLeftStable,
+    onCenterStable,
+    onRightStable,
+    onSubmitStable,
+  ]);
 
   // Expose an imperative API (validate/getValue/setValue)
   useImperativeHandle(

--- a/apps/package/src/web-components/wavelength-form.ts
+++ b/apps/package/src/web-components/wavelength-form.ts
@@ -315,6 +315,11 @@ export class WavelengthForm<T extends object> extends HTMLElement {
   private onSubmit = (e: Event) => {
     e.preventDefault();
     const res = this.validateAll();
+    const submitEvent =
+      typeof SubmitEvent === "function"
+        ? new SubmitEvent("submit", { bubbles: true, cancelable: true, composed: true })
+        : new Event("submit", { bubbles: true, cancelable: true, composed: true });
+    this.dispatchEvent(submitEvent);
     if (res.isValid) {
       this.dispatchEvent(new CustomEvent("form-valid", { detail: { value: res.value, issues: [] } }));
     } else {
@@ -465,9 +470,10 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     const rightSlot = document.createElement("div");
     rightSlot.className = "right";
 
-    const buildButton = (cfg: ButtonConfig, defaultEvent: string, defaultType: "button" | "submit") => {
+    const buildButton = (cfg: ButtonConfig, defaultEvent: string) => {
       const btn = document.createElement("wavelength-button");
-      const type = (cfg.buttonProps?.type as string) ?? defaultType;
+      const requestedType = (cfg.buttonProps?.type as string) ?? "";
+      const type = requestedType === "submit" ? "submit" : "button";
       if (cfg.buttonProps) {
         for (const [key, value] of Object.entries(cfg.buttonProps)) {
           if (key === "type") continue;
@@ -478,7 +484,7 @@ export class WavelengthForm<T extends object> extends HTMLElement {
       if (cfg.label) btn.textContent = cfg.label;
       btn.addEventListener("click", (e) => {
         const ev = cfg.eventName ?? defaultEvent;
-        if (type === "submit") {
+        if (requestedType === "submit") {
           form.requestSubmit();
         } else {
           e.preventDefault();
@@ -489,15 +495,15 @@ export class WavelengthForm<T extends object> extends HTMLElement {
     };
 
     if (this._leftButton) {
-      leftSlot.appendChild(buildButton(this._leftButton, "form-back", "button"));
+      leftSlot.appendChild(buildButton(this._leftButton, "form-left"));
     }
 
     if (this._centerButton) {
-      centerSlot.appendChild(buildButton(this._centerButton, "form-center", "button"));
+      centerSlot.appendChild(buildButton(this._centerButton, "form-center"));
     }
 
     if (this._rightButton) {
-      rightSlot.appendChild(buildButton(this._rightButton, "form-submit", "submit"));
+      rightSlot.appendChild(buildButton(this._rightButton, "form-right"));
     }
 
     if (leftSlot.children.length + centerSlot.children.length + rightSlot.children.length > 0) {

--- a/apps/testbed/src/stories/Form.stories.tsx
+++ b/apps/testbed/src/stories/Form.stories.tsx
@@ -68,23 +68,25 @@ const schema = z.object({ firstName: z.string(), lastName: z.string() });
   lastName: z.string().min(1),
 });
 
-<WavelengthForm schema={schema} onSubmit={(data) => console.log(data)} />`}
+<WavelengthForm schema={schema} onValid={(data) => console.log(data)} />`}
             language="tsx"
           />
           <h2>Custom Buttons & Events</h2>
           <p>
-            Use <code>onBack</code>, <code>onCenter</code>, <code>onRight</code>, and <code>onSubmit</code> to respond to button clicks or form submission.
+            Use <code>onLeft</code>, <code>onCenter</code>, <code>onRight</code>, and <code>onSubmit</code> (native submit) to
+            respond to button clicks or form submission. Set <code>buttonProps.type</code> to
+            <code>&#39;submit&#39;</code> on any button when you want it to trigger the form submission flow.
           </p>
           <Source
             code={`<WavelengthForm
   schema={schema}
   leftButton={{ label: 'Back' }}
   centerButton={{ label: 'Help' }}
-  rightButton={{ label: 'Next' }}
-  onBack={() => console.log('back')}
+  rightButton={{ label: 'Next', buttonProps: { type: 'submit' } }}
+  onLeft={() => console.log('left')}
   onCenter={() => console.log('center')}
   onRight={() => console.log('right')}
-  onSubmit={(values) => console.log('submit', values)}
+  onSubmit={(event) => console.log('submit', event)}
 />`}
             language="tsx"
           />
@@ -188,7 +190,7 @@ export const CustomFormWidth: Story = {
   render: (args) => <WavelengthForm {...args} />,
 };
 
-export const WithBackButton: Story = {
+export const WithLeftButton: Story = {
   args: {
     schema: sampleSchema,
     value: { firstName: "Clark", lastName: "Kent" },
@@ -197,7 +199,7 @@ export const WithBackButton: Story = {
       buttonProps: { id: "back-btn", variant: "text", size: "small" },
     },
   },
-  render: (args) => <WavelengthForm {...args} onBack={() => console.log("back")} />,
+  render: (args) => <WavelengthForm {...args} onLeft={() => console.log("left")} />,
 };
 
 export const WithCenterButton: Story = {
@@ -299,8 +301,12 @@ export const WithSubmitHandler: Story = {
   args: {
     schema: sampleSchema,
     value: { firstName: "Clark", lastName: "Kent" },
+    rightButton: {
+      label: "Submit",
+      buttonProps: { type: "submit" },
+    },
   },
-  render: (args) => <WavelengthForm {...args} onSubmit={(data) => console.log("submit", data)} />,
+  render: (args) => <WavelengthForm {...args} onSubmit={(event) => console.log("submit", event)} />,
 };
 
 export const WithButtonEvents: Story = {
@@ -311,7 +317,14 @@ export const WithButtonEvents: Story = {
     centerButton: { label: "Help" },
     rightButton: { label: "Next" },
   },
-  render: (args) => <WavelengthForm {...args} onBack={() => console.log("back")} onCenter={() => console.log("center")} onRight={() => console.log("right")} />,
+  render: (args) => (
+    <WavelengthForm
+      {...args}
+      onLeft={() => console.log("left")}
+      onCenter={() => console.log("center")}
+      onRight={() => console.log("right")}
+    />
+  ),
 };
 
 export const MultiRowLayout: Story = {


### PR DESCRIPTION
## Summary
- rename the wavelength-form default button events and requestSubmit handling so buttons default to type="button" while still allowing submit buttons to trigger validation and a native submit event
- expose matching onLeft/onCenter/onRight callbacks plus a native submit hook from the React wrapper
- refresh README and Storybook examples and adjust Jest coverage for the new events and submit behaviour

## Testing
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68c97319e6c88325abeb7e22fe761d14