### PR TITLE
Guard web component registration and expose classes

### DIFF
--- a/apps/package/src/components/TextField/WavelengthInput.tsx
+++ b/apps/package/src/components/TextField/WavelengthInput.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, forwardRef, useImperativeHandle, ChangeEvent, CSSProperties } from "react";
+import "../../web-components/wavelength-input";
 
 interface WavelengthInputProps extends React.HTMLAttributes<HTMLElement> {
   id?: string;

--- a/apps/package/src/components/forms/WavelengthForm.tsx
+++ b/apps/package/src/components/forms/WavelengthForm.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useImperativeHandle, useRef } from "react";
+import "../web-components/wavelength-form";
 import { z } from "zod";
 
 // ---- Types that mirror the web component's API ----

--- a/apps/package/src/index.ts
+++ b/apps/package/src/index.ts
@@ -15,6 +15,17 @@ import "./web-components/wavelength-form";
 import "./web-components/wavelength-progress-bar";
 import "./web-components/wavelength-input";
 import "./web-components/wavelength-title-bar";
+import "./web-components/input-datepicker";
+
+// Web Component Class Exports
+export { SampleComponent } from "./web-components/sample-component";
+export { WavelengthBanner } from "./web-components/wavelength-banner";
+export { WavelengthButton } from "./web-components/wavelength-button";
+export { WavelengthForm as WavelengthFormElement } from "./web-components/wavelength-form";
+export { WavelengthProgressBar } from "./web-components/wavelength-progress-bar";
+export { WavelengthInput as WavelengthInputElement } from "./web-components/wavelength-input";
+export { WavelengthTitleBar } from "./web-components/wavelength-title-bar";
+export { WLInputDatePicker } from "./web-components/input-datepicker";
 
 // Function Exports
 export * from "./functions/math";

--- a/apps/package/src/web-components/input-datepicker.ts
+++ b/apps/package/src/web-components/input-datepicker.ts
@@ -31,4 +31,6 @@ export class WLInputDatePicker extends HTMLElement {
   }
 }
 
-customElements.define("wavelength-input-date-picker", WLInputDatePicker);
+if (!customElements.get("wavelength-input-date-picker")) {
+  customElements.define("wavelength-input-date-picker", WLInputDatePicker);
+}

--- a/apps/package/src/web-components/wavelength-progress-bar.ts
+++ b/apps/package/src/web-components/wavelength-progress-bar.ts
@@ -90,4 +90,6 @@ export class WavelengthProgressBar extends HTMLElement {
   }
 }
 
-customElements.define("wavelength-progress-bar", WavelengthProgressBar);
+if (!customElements.get("wavelength-progress-bar")) {
+  customElements.define("wavelength-progress-bar", WavelengthProgressBar);
+}


### PR DESCRIPTION
## Summary
- guard the wavelength progress bar and date picker custom element registrations
- ensure React wrappers import their web component definitions for side effects
- update the package index to import every custom element and re-export their classes for direct access

## Testing
- npm run lint *(fails: existing prettier/prettier formatting complaints across multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6bc433188325a7dd8b464d1fbfe9