### PR TITLE
Use workspace reference for web components dependency

### DIFF
--- a/apps/packages/react-components/package.json
+++ b/apps/packages/react-components/package.json
@@ -65,7 +65,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.16.5",
     "@mui/material": "^5.15.7",
-    "@wavelengthusaf/web-components": "^1.0.1",
+    "@wavelengthusaf/web-components": "workspace:*",
     "react": "^18.2.0",
     "react-router-dom": "^6.26.2",
     "styled-components": "^6.1.12",


### PR DESCRIPTION
## Summary
- update the React components package to consume the local web-components workspace using the workspace protocol

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b59dba708325980211aa56f6a85f