### PR TITLE
Restore React exports and add primitive aliases

### DIFF
--- a/apps/packages/react-components/src/index.ts
+++ b/apps/packages/react-components/src/index.ts
@@ -11,7 +11,8 @@ export * from "./functions/math";
 export * from "./functions/string";
 
 // Buttons
-export { WavelengthButton } from "@wavelengthusaf/web-components";
+export { WavelengthButton } from "./components/buttons/WavelengthButton/WavelengthButton";
+export { WavelengthButton as WavelengthButtonElement } from "@wavelengthusaf/web-components";
 export * from "./components/buttons/WavelengthDropdownButton/WavelengthDropdownButton";
 export * from "./components/buttons/WavelengthDropdownButton/WavelengthAutocomplete";
 export * from "./components/buttons/WavelengthFileDownloader";
@@ -34,7 +35,8 @@ export * from "./components/PageComponents/WavelengthSideBar";
 export * from "./components/PageComponents/WavelengthSpinningLogo";
 export * from "./components/PageComponents/WavelengthSpinningLogoComponent";
 export * from "./components/PageComponents/WavelengthDragAndDrop";
-export { WavelengthProgressBar } from "@wavelengthusaf/web-components";
+export { WavelengthProgressBar } from "./components/PageComponents/WavelengthProgressBar";
+export { WavelengthProgressBar as WavelengthProgressBarElement } from "@wavelengthusaf/web-components";
 export * from "./components/PageComponents/WavelengthCommentDisplay";
 export * from "./components/PageComponents/WavelengthPermissionAlert";
 export * from "./components/PageComponents/WavelengthAccessAlert";
@@ -44,11 +46,14 @@ export * from "./components/PageComponents/WavelengthAlert";
 export * from "./components/footers/WavelengthFooter/WavelengthFooter";
 
 // Forms
-export { WavelengthForm } from "@wavelengthusaf/web-components";
+export { WavelengthForm } from "./components/forms/WavelengthForm";
+export { WavelengthForm as WavelengthFormElement } from "@wavelengthusaf/web-components";
 
 // Headers
-export { WavelengthTitleBar } from "@wavelengthusaf/web-components";
-export { WavelengthBanner } from "@wavelengthusaf/web-components";
+export { WavelengthTitleBar } from "./components/headers/WavelengthTitleBar/WavelengthTitleBar";
+export { WavelengthTitleBar as WavelengthTitleBarElement } from "@wavelengthusaf/web-components";
+export { WavelengthBanner } from "./components/headers/WavelengthTitleBar/WavelengthBanner";
+export { WavelengthBanner as WavelengthBannerElement } from "@wavelengthusaf/web-components";
 
 // Logos
 export * from "./components/logos/applogo/WavelengthAppLogo";
@@ -83,7 +88,8 @@ export * from "./components/carousels/WavelengthSliderCarousel";
 export * from "./components/pagination/WavelengthDefaultPagination";
 
 // TextField
-export { WavelengthInput } from "@wavelengthusaf/web-components";
+export { WavelengthInput } from "./components/TextField/WavelengthInput";
+export { WavelengthInput as WavelengthInputElement } from "@wavelengthusaf/web-components";
 
 // DataTable
 export * from "./components/DataTable/WavelengthDataTable";
@@ -94,7 +100,9 @@ export * from "./components/DataTable/NestedDataTable/NestedDataTable";
 export * from "./components/AutoComplete/WavelengthAutoComplete";
 
 // Inputs
-export { WavelengthDatePicker } from "@wavelengthusaf/web-components";
+export { WavelengthDatePicker } from "./components/inputs/WavelengthDatePicker";
+export { WavelengthDatePicker as WavelengthDatePickerElement } from "@wavelengthusaf/web-components";
 
 // Samples
-export { SampleComponent } from "@wavelengthusaf/web-components";
+export { SampleComponent } from "./components/samples/SampleComponent";
+export { SampleComponent as SampleComponentElement } from "@wavelengthusaf/web-components";

--- a/apps/packages/react-components/src/types/custom.d.ts
+++ b/apps/packages/react-components/src/types/custom.d.ts
@@ -17,3 +17,14 @@ declare module "*.json" {
   const content: string;
   export default content;
 }
+
+declare module "@wavelengthusaf/web-components" {
+  export class SampleComponent extends HTMLElement {}
+  export class WavelengthBanner extends HTMLElement {}
+  export class WavelengthButton extends HTMLElement {}
+  export class WavelengthDatePicker extends HTMLElement {}
+  export class WavelengthForm extends HTMLElement {}
+  export class WavelengthInput extends HTMLElement {}
+  export class WavelengthProgressBar extends HTMLElement {}
+  export class WavelengthTitleBar extends HTMLElement {}
+}


### PR DESCRIPTION
## Summary
- re-export React implementations for legacy components from their component directories
- add alias exports for the underlying web component classes to provide direct element access
- declare the web-components module types so the build can generate declarations cleanly

## Testing
- npm run build:react

------
https://chatgpt.com/codex/tasks/task_e_68d2bfc4b9448325aefa91c4faca9a6b