### PR TITLE
Ensure web-components build precedes react build

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -12,6 +12,8 @@
 
 1. After making a new branch, run the `super_build.sh` script. Once the script finishes, all node modules should be installed and built, and the directories linked to each other. You are now ready to start developing!
 
+1. Building the React component package (`npm run build:react`) will now automatically build the Web Components workspace first so that `@wavelengthusaf/web-components` type declarations are always available. You no longer need to manually run the Web Components build before compiling React components from a clean checkout.
+
 1. For building new components, It is recommended to copy an existing component, and changing the necessary code to match the design you are working with. The same goes for the webpage; copy an existing webpage and change it to your needs.
 
 1. When you are ready to push changes to your branch, run the `pipeline_check.sh` script to ensure that your changes will pass the pipeline. If any of the stages fails, go back and fix any issues and then run the script again.

--- a/apps/packages/react-components/package.json
+++ b/apps/packages/react-components/package.json
@@ -19,6 +19,7 @@
     "dist/**/*"
   ],
   "scripts": {
+    "prebuild": "npm run build --workspace @wavelengthusaf/web-components",
     "compile": "tsc",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "jest --runInBand --coverage",
@@ -65,7 +66,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.16.5",
     "@mui/material": "^5.15.7",
-    "@wavelengthusaf/web-components": "workspace:*",
+    "@wavelengthusaf/web-components": "file:../web-components",
     "react": "^18.2.0",
     "react-router-dom": "^6.26.2",
     "styled-components": "^6.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,6 @@
       "name": "common-components",
       "version": "0.0.0",
       "license": "MIT",
-      "workspaces": [
-        "/apps/packages/web-components",
-        "/apps/packages/react-components",
-        "/apps/testbed"
-      ],
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
@@ -62,6 +57,12 @@
         "ts-node": "^10.9.2",
         "tsup": "^8.0.1",
         "vite": "^5.4.9"
+      },
+      "workspaces": {
+        "packages": [
+          "apps/packages/*",
+          "apps/testbed"
+        ]
       }
     },
     "apps/packages/react-components": {
@@ -73,7 +74,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.16.5",
         "@mui/material": "^5.15.7",
-        "@wavelengthusaf/web-components": "^1.0.1",
+        "@wavelengthusaf/web-components": "file:../web-components",
         "react": "^18.2.0",
         "react-router-dom": "^6.26.2",
         "styled-components": "^6.1.12",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "description": "Common component library used by Wavelength developers",
   "type": "module",
   "private": true,
-  "workspaces": [
-    "/apps/packages/web-components",
-    "/apps/packages/react-components",
-    "/apps/testbed"
-  ],
+  "workspaces": {
+    "packages": [
+      "apps/packages/*",
+      "apps/testbed"
+    ]
+  },
   "files": [
     "./apps/packages/web-components/dist",
     "./apps/packages/react-components/dist",


### PR DESCRIPTION
## Summary
- add a prebuild hook for the React package so the web-components workspace builds before the React artifacts
- normalize workspace configuration to support npm installs and document the automatic dependency build for contributors

## Testing
- npm run build:react

------
https://chatgpt.com/codex/tasks/task_e_68d2c2954d988325a0c4fecfb5217977