### PR TITLE
chore: consume published web components package

### DIFF
--- a/apps/packages/react-components/package.json
+++ b/apps/packages/react-components/package.json
@@ -66,7 +66,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.16.5",
     "@mui/material": "^5.15.7",
-    "@wavelengthusaf/web-components": "file:../web-components",
+    "@wavelengthusaf/web-components": "^1.0.1",
     "react": "^18.2.0",
     "react-router-dom": "^6.26.2",
     "styled-components": "^6.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.16.5",
         "@mui/material": "^5.15.7",
-        "@wavelengthusaf/web-components": "file:../web-components",
+        "@wavelengthusaf/web-components": "^1.0.1",
         "react": "^18.2.0",
         "react-router-dom": "^6.26.2",
         "styled-components": "^6.1.12",


### PR DESCRIPTION
## Summary
- update the React component package to depend on the published `@wavelengthusaf/web-components` range
- refresh the workspace lockfile so the dependency is represented with the versioned range

## Testing
- CI=1 npm run build
- CI=1 npm run test:react

------
https://chatgpt.com/codex/tasks/task_e_68d2e0241dac8325811a5518e4b416d1