### PR TITLE
Ensure workspace metadata resolution uses path.resolve

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,8 +61,8 @@ deploy_packages:
       publish_package() {
         local package_dir="$1"
         local package_name package_version
-        package_name=$(node -p "require('${package_dir}/package.json').name")
-        package_version=$(node -p "require('${package_dir}/package.json').version")
+        package_name=$(node -p "const path=require('path');require(path.resolve('${package_dir}', 'package.json')).name")
+        package_version=$(node -p "const path=require('path');require(path.resolve('${package_dir}', 'package.json')).version")
         if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
           echo "${package_name}@${package_version} already exists, skipping publish."
         else

--- a/pipeline_check.sh
+++ b/pipeline_check.sh
@@ -25,7 +25,7 @@ cleanup_tarball() {
 check_react_dependency_range() {
     local web_version="$1"
     local react_range
-    react_range=$(node -p "require('${REACT_DIR}/package.json').dependencies['@wavelengthusaf/web-components']")
+    react_range=$(node -p "const path=require('path');require(path.resolve('${REACT_DIR}', 'package.json')).dependencies['@wavelengthusaf/web-components']")
 
     if ! npx --yes semver "$web_version" -r "$react_range" >/dev/null 2>&1; then
         echo -e "${RED}React dependency range '${react_range}' does not include web components version ${web_version}.${NC}"
@@ -51,7 +51,7 @@ pack_workspace() {
 
     if [ "$workspace_dir" = "$WEB_DIR" ]; then
         local web_version
-        web_version=$(node -p "require('${workspace_dir}/package.json').version")
+        web_version=$(node -p "const path=require('path');require(path.resolve('${workspace_dir}', 'package.json')).version")
         check_react_dependency_range "$web_version"
     fi
 


### PR DESCRIPTION
## Summary
- resolve workspace package.json paths in publish helper via Node's path.resolve
- update pipeline_check.sh to read package metadata with the same path resolution logic

## Testing
- bash pipeline_check.sh *(fails: jest fallback slot expectation for wavelength-button)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f0bd7cc483258be54b3aff50b584