### PR TITLE
Add Jest mapper for web-components source

### DIFF
--- a/apps/packages/react-components/jest.config.js
+++ b/apps/packages/react-components/jest.config.js
@@ -5,6 +5,11 @@ export default {
     "^.+\\.tsx?$": "ts-jest",
     "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
   },
+  moduleNameMapper: {
+    "^@wavelengthusaf/web-components$": "<rootDir>/../web-components/src/index.ts",
+    "^@wavelengthusaf/web-components/fonts/(.*)$": "<rootDir>/jest/__mocks__/fileMock.js",
+    "^@wavelengthusaf/web-components/(.*)$": "<rootDir>/../web-components/src/$1",
+  },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   transformIgnorePatterns: ["node_modules"],
   testMatch: ["<rootDir>/jest/**/*.test.ts", "<rootDir>/jest/**/*.test.tsx"],

--- a/apps/packages/react-components/jest/__mocks__/fileMock.js
+++ b/apps/packages/react-components/jest/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";


### PR DESCRIPTION
## Summary
- map @wavelengthusaf/web-components to the workspace source files for Jest
- provide a font asset stub so mapped imports do not require dist artifacts

## Testing
- npm run test:react

------
https://chatgpt.com/codex/tasks/task_e_68d40760e42883258adc1479d72fcc77