### PR TITLE
chore: prevent bundling zod in web components build

### DIFF
--- a/apps/packages/web-components/tsup.config.ts
+++ b/apps/packages/web-components/tsup.config.ts
@@ -10,4 +10,5 @@ export default defineConfig({
   outDir: "dist",
   minify: false,
   target: "es2020",
+  external: ["zod"],
 });


### PR DESCRIPTION
## Summary
- configure tsup to treat zod as an external dependency so it is no longer bundled into the web-components outputs

## Testing
- npm run build --workspace @wavelengthusaf/web-components
- npm pack --workspace @wavelengthusaf/web-components --pack-destination tmp/


------
https://chatgpt.com/codex/tasks/task_e_68d41ac135ec8325beb37ee66ee260df