### PR TITLE
Restore NPM_TOKEN variable mapping

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,9 @@ stages:
   - post_deploy
   - pages
 
+variables:
+  NPM_TOKEN: $NPM_AUTH_TOKEN
+
 default:
   image: node:20
   before_script:
@@ -89,11 +92,12 @@ deploy_packages:
       }
     - |
       if [ "${CI_COMMIT_BRANCH}" = "main" ]; then
-        if [ -z "${NPM_TOKEN:-}" ]; then
-          echo "NPM_TOKEN is required to publish" >&2
+        npm_token="${NPM_TOKEN:-${NODE_AUTH_TOKEN:-}}"
+        if [ -z "${npm_token}" ]; then
+          echo "NPM_TOKEN or NODE_AUTH_TOKEN is required to publish" >&2
           exit 1
         fi
-        npm config set //registry.npmjs.org/:_authToken="${NPM_TOKEN}"
+        npm config set //registry.npmjs.org/:_authToken="${npm_token}"
         publish_package apps/packages/web-components
         publish_package apps/packages/react-components
       else

--- a/docs/dual-publish/release-workflow.md
+++ b/docs/dual-publish/release-workflow.md
@@ -74,7 +74,7 @@ The repository ships with both a local helper script and a GitLab pipeline that 
 2. **CI stages** – the [`.gitlab-ci.yml`](../../.gitlab-ci.yml) pipeline performs the same steps and, on `main`, publishes the packages and Storybook:
    - `install_dependencies` installs all workspaces and caches the `node_modules` folders.
    - `build_packages` runs `npm run build:packages` so both `dist/` folders are ready.
-   - `deploy_packages` packs both packages on branches and publishes them when running on `main` (requires `NPM_TOKEN`).
+  - `deploy_packages` packs both packages on branches and publishes them when running on `main` (requires an npm auth token exposed via `NPM_TOKEN` or `NODE_AUTH_TOKEN`).
    - `storybook_build` builds the `common-components-testbed` Storybook using the freshly built packages.
    - `pages` publishes the Storybook static site when the pipeline runs on `main`.
 


### PR DESCRIPTION
## Summary
- restore the top-level CI variable that maps NPM_TOKEN to the NPM_AUTH_TOKEN secret so publishes keep working

## Testing
- not run (CI configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d434270810832599a6d53d37d2f3e4